### PR TITLE
Experiment with fully integrating EventBus 7 into Forge

### DIFF
--- a/build_shared.gradle
+++ b/build_shared.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
     maven gradleutils.forgeMaven
     maven gradleutils.minecraftLibsMaven
-    //mavenLocal()
+    mavenLocal()
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/Bindings.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/Bindings.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.loading.FMLLoader;
 
@@ -25,13 +24,6 @@ public class Bindings {
      */
     private static final IBindingsProvider PROVIDER = ServiceLoader.load(FMLLoader.getGameLayer(), IBindingsProvider.class)
             .findFirst().orElseThrow(() -> new IllegalStateException("Could not find bindings provider"));
-
-    /**
-     * @return A supplier of net.minecraftforge.common.MinecraftForge#EVENT_BUS
-     */
-    public static Supplier<IEventBus> getForgeBus() {
-        return PROVIDER.getForgeBusSupplier();
-    }
 
     public static Supplier<I18NParser> getMessageParser() {
         return PROVIDER.getMessageParser();

--- a/fmlcore/src/main/java/net/minecraftforge/fml/IBindingsProvider.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IBindingsProvider.java
@@ -5,13 +5,11 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.config.IConfigEvent;
 
 import java.util.function.Supplier;
 
 public interface IBindingsProvider {
-    Supplier<IEventBus> getForgeBusSupplier();
     Supplier<I18NParser> getMessageParser();
     Supplier<IConfigEvent.ConfigConfig> getConfigConfiguration();
 }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/IModLoadingState.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IModLoadingState.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.loading.progress.ProgressMeter;
 
@@ -68,7 +67,7 @@ public interface IModLoadingState {
      * @return a transition task for this state
      * @see #buildTransition(Executor, Executor, ProgressMeter, Function, Function)
      */
-    default <T extends Event & IModBusEvent> Optional<CompletableFuture<Void>> buildTransition(
+    default <T extends IModBusEvent> Optional<CompletableFuture<Void>> buildTransition(
         final Executor syncExecutor,
         final Executor parallelExecutor,
         final ProgressMeter progressBar
@@ -91,7 +90,7 @@ public interface IModLoadingState {
      * @param postSyncTask     a function which returns a task to run after event post-dispatch hook
      * @return a transition task for this state
      */
-    <T extends Event & IModBusEvent>
+    <T extends IModBusEvent>
     Optional<CompletableFuture<Void>> buildTransition(final Executor syncExecutor,
                                                       final Executor parallelExecutor,
                                                       final ProgressMeter progressBar,

--- a/fmlcore/src/main/java/net/minecraftforge/fml/IModStateTransition.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/IModStateTransition.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.loading.progress.ProgressMeter;
 
@@ -51,7 +50,7 @@ public interface IModStateTransition {
     }
 
     @Nullable
-    default <T extends Event & IModBusEvent> EventGenerator<T> eventFunction() {
+    default <T extends IModBusEvent> EventGenerator<T> eventFunction() {
         return null;
     }
 
@@ -74,8 +73,8 @@ public interface IModStateTransition {
     @Deprecated(since = "1.21.3", forRemoval = true)
     default BiFunction<Executor, ? extends EventGenerator<?>, CompletableFuture<Void>> postDispatchHook() { return NULL_HOOK; }
 
-    interface EventGenerator<T extends Event & IModBusEvent> extends Function<ModContainer, T> {
-        static <FN extends Event & IModBusEvent> EventGenerator<FN> fromFunction(Function<ModContainer, FN> fn) {
+    interface EventGenerator<T extends IModBusEvent> extends Function<ModContainer, T> {
+        static <FN extends IModBusEvent> EventGenerator<FN> fromFunction(Function<ModContainer, FN> fn) {
             return fn::apply;
         }
     }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -162,5 +161,5 @@ public abstract class ModContainer {
      * Accept an arbitrary event for processing by the mod. Probably posted to an event bus in the lower level container.
      * @param e Event to accept
      */
-    protected <T extends Event & IModBusEvent> void acceptEvent(T e) {}
+    protected <T extends IModBusEvent> void acceptEvent(T e) {}
 }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -6,7 +6,6 @@
 package net.minecraftforge.fml;
 
 import com.google.common.collect.ImmutableList;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fml.loading.FMLLoader;
@@ -357,7 +356,7 @@ public class ModLoader {
         return completedStates.contains(state);
     }
 
-    public <T extends Event & IModBusEvent> void runEventGenerator(Function<ModContainer, T> generator) {
+    public <T extends IModBusEvent> void runEventGenerator(Function<ModContainer, T> generator) {
         if (!loadingStateValid) {
             LOGGER.error("Cowardly refusing to send event generator to a broken mod state");
             return;
@@ -365,7 +364,7 @@ public class ModLoader {
         ModList.get().forEachModInOrder(mc -> mc.acceptEvent(generator.apply(mc)));
     }
 
-    public <T extends Event & IModBusEvent> void postEvent(T e) {
+    public <T extends IModBusEvent> void postEvent(T e) {
         if (!loadingStateValid) {
             LOGGER.error("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
             return;
@@ -373,7 +372,7 @@ public class ModLoader {
         ModList.get().forEachModInOrder(mc -> mc.acceptEvent(e));
     }
 
-    public <T extends Event & IModBusEvent> T postEventWithReturn(T e) {
+    public <T extends IModBusEvent> T postEventWithReturn(T e) {
         if (!loadingStateValid) {
             LOGGER.error("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
             return e;
@@ -383,14 +382,14 @@ public class ModLoader {
     }
 
     @SuppressWarnings("removal")
-    public <T extends Event & IModBusEvent> void postEventWrapContainerInModOrder(T event) {
+    public <T extends IModBusEvent> void postEventWrapContainerInModOrder(T event) {
         postEventWithWrapInModOrder(event,
             (mc, e) -> ModLoadingContext.get().setActiveContainer(mc),
             (mc, e) -> ModLoadingContext.get().setActiveContainer(null)
         );
     }
 
-    public <T extends Event & IModBusEvent> void postEventWithWrapInModOrder(T e, BiConsumer<ModContainer, T> pre, BiConsumer<ModContainer, T> post) {
+    public <T extends IModBusEvent> void postEventWithWrapInModOrder(T e, BiConsumer<ModContainer, T> pre, BiConsumer<ModContainer, T> post) {
         if (!loadingStateValid) {
             LOGGER.error("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
             return;

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingState.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModLoadingState.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.loading.progress.ProgressMeter;
 
@@ -36,7 +35,7 @@ public record ModLoadingState(
     Optional<IModStateTransition> transition
 ) implements IModLoadingState {
     @Override
-    public <T extends Event & IModBusEvent> Optional<CompletableFuture<Void>> buildTransition(
+    public <T extends IModBusEvent> Optional<CompletableFuture<Void>> buildTransition(
         final Executor syncExecutor,
         final Executor parallelExecutor,
         final ProgressMeter progressBar,

--- a/fmlcore/src/main/java/net/minecraftforge/fml/ModStateTransitionHelper.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/ModStateTransitionHelper.java
@@ -17,7 +17,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.jetbrains.annotations.ApiStatus;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.IModStateTransition.EventGenerator;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.loading.progress.ProgressMeter;
@@ -76,7 +75,7 @@ class ModStateTransitionHelper {
         return CompletableFuture.allOf(results).handle((r, th)->null).thenApply(res -> list);
     }
 
-    private static <T extends Event & IModBusEvent> void addCompletableFutureTaskForModDispatch(
+    private static <T extends IModBusEvent> void addCompletableFutureTaskForModDispatch(
         final IModStateTransition transition,
         final Executor executor,
         final List<CompletableFuture<Void>> completableFutures,
@@ -135,14 +134,14 @@ class ModStateTransitionHelper {
             completableFutures.add(postDispatchHook);
     }
 
-    private static <T extends Event & IModBusEvent> CompletableFuture<Void> getHook(BiFunction<Executor, ? extends EventGenerator<?>, CompletableFuture<Void>> hook, Executor executor, EventGenerator<T> eventGenerator) {
+    private static <T extends IModBusEvent> CompletableFuture<Void> getHook(BiFunction<Executor, ? extends EventGenerator<?>, CompletableFuture<Void>> hook, Executor executor, EventGenerator<T> eventGenerator) {
         if (hook == null || hook == IModStateTransition.NULL_HOOK) return null;
         @SuppressWarnings("unchecked")
         var hookTyped = (BiFunction<Executor, EventGenerator<T>, CompletableFuture<Void>>)hook;
         return hookTyped.apply(executor, eventGenerator);
     }
 
-    static <T extends Event & IModBusEvent> CompletableFuture<Void> build(
+    static <T extends IModBusEvent> CompletableFuture<Void> build(
         final IModStateTransition transition,
         final String name,
         final Executor syncExecutor,

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
@@ -5,13 +5,14 @@
 
 package net.minecraftforge.fml.config;
 
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
 import net.minecraftforge.fml.Bindings;
 
 import java.util.function.Function;
 
 import org.jetbrains.annotations.Nullable;
 
-public interface IConfigEvent {
+public interface IConfigEvent extends InheritableEvent {
     record ConfigConfig(Function<ModConfig, IConfigEvent> loading, Function<ModConfig, IConfigEvent> reloading, @Nullable Function<ModConfig, IConfigEvent> unloading) {}
 
     ConfigConfig CONFIGCONFIG = Bindings.getConfigConfiguration().get();

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/IConfigEvent.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml.config;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.Bindings;
 
 import java.util.function.Function;
@@ -29,7 +28,7 @@ public interface IConfigEvent {
     ModConfig getConfig();
 
     @SuppressWarnings("unchecked")
-    default <T extends Event & IConfigEvent> T self() {
+    default <T extends IConfigEvent> T self() {
         return (T) this;
     }
 }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/event/IModBusEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/event/IModBusEvent.java
@@ -5,8 +5,10 @@
 
 package net.minecraftforge.fml.event;
 
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
+
 /**
  * Marker interface for events dispatched on the ModLifecycle event bus instead of the primary event bus
  */
-public interface IModBusEvent {
+public interface IModBusEvent extends InheritableEvent {
 }

--- a/fmlcore/src/main/java/net/minecraftforge/fml/event/IModBusEvent.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/event/IModBusEvent.java
@@ -5,10 +5,23 @@
 
 package net.minecraftforge.fml.event;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.InheritableEvent;
 
 /**
  * Marker interface for events dispatched on the ModLifecycle event bus instead of the primary event bus
  */
 public interface IModBusEvent extends InheritableEvent {
+    static <T extends IModBusEvent> EventBus<T> getBus(BusGroup modEventBusGroup, Class<T> eventClass) {
+        // Do not copy! Temporary solution until the FML rewrite is complete. May throw in future
+        // without prior notice.
+        //
+        // Mods creating their own events should directly assign the result of the create method to a
+        // static final field in their event class, without wrapping or calling multiple times.
+        //
+        // Mods using existing events should instead use the existing static final BUS field in the
+        // event class (for most events) or getBus(BusGroup) method (for mod bus events).
+        return EventBus.create(modEventBusGroup, eventClass);
+    }
 }

--- a/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/fmlloader/src/main/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -56,7 +56,6 @@ public class FMLLoader {
 
         checkPackage(ITransformationService.class, "4.0", "ModLauncher");
         accessTransformer  = getPlugin(env, "accesstransformer",  "1.0", "AccessTransformer");
-        /*eventBus       =*/ getPlugin(env, "eventbus",           "1.0", "EventBus");
         runtimeDistCleaner = getPlugin(env, "runtimedistcleaner", "1.0", "RuntimeDistCleaner");
         coreModProvider = getSingleService(ICoreModProvider.class, "CoreMod");
         LOGGER.debug(CORE, "FML found CoreMod version : {}", JarVersionLookupHandler.getInfo(coreModProvider.getClass()).impl().version().orElse("MISSING"));

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -12,8 +12,7 @@ import java.lang.annotation.Target;
 import java.util.function.Supplier;
 
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.Bindings;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 /**
@@ -73,21 +72,21 @@ public @interface Mod
              *
              * <p>See {@code MinecraftForge#EVENT_BUS}</p>
              */
-            FORGE(Bindings.getForgeBus()),
+            FORGE(() -> BusGroup.DEFAULT),
             /**
-             * The mod specific Event bus.
+             * The mod specific event BusGroup.
              * @see FMLJavaModLoadingContext#getModEventBus()
              */
             MOD(()-> FMLJavaModLoadingContext.get().getModEventBus());
 
-            private final Supplier<IEventBus> busSupplier;
+            private final Supplier<BusGroup> busGroupSupplier;
 
-            Bus(final Supplier<IEventBus> eventBusSupplier) {
-                this.busSupplier = eventBusSupplier;
+            Bus(final Supplier<BusGroup> busGroupSupplier) {
+                this.busGroupSupplier = busGroupSupplier;
             }
 
-            public Supplier<IEventBus> bus() {
-                return busSupplier;
+            public Supplier<BusGroup> bus() {
+                return busGroupSupplier;
             }
         }
     }

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -16,10 +16,12 @@ import net.minecraftforge.forgespi.language.ModFileScanData;
 import net.minecraftforge.forgespi.language.ModFileScanData.AnnotationData;
 import net.minecraftforge.forgespi.language.ModFileScanData.EnumData;
 import net.minecraftforge.fml.loading.FMLEnvironment;
+import net.minecraftforge.unsafe.UnsafeHacks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Type;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -73,14 +75,20 @@ public class AutomaticEventSubscriber {
             var busName = value(data, "bus", defaultBus).value();
             var busTarget = Bus.valueOf(busName);
             if (Objects.equals(mod.getModId(), modId) && sides.contains(FMLEnvironment.dist)) {
-//                try {
+                try {
                     LOGGER.debug(Logging.LOADING, "Auto-subscribing {} to {}", data.clazz().getClassName(), busTarget);
-                    throw new RuntimeException("Todo: [FML][EventBusSubscriber] Adjust EventBusSubscriber to support EventBus v7");
+                    var lookupField = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+                    UnsafeHacks.setAccessible(lookupField);
+                    var lookup = (MethodHandles.Lookup) lookupField.get(null);
+                    busTarget.bus().get().register(lookup, Class.forName(data.clazz().getClassName(), true, loader));
+//                    throw new RuntimeException("Todo: [FML][EventBusSubscriber] Adjust EventBusSubscriber to support EventBus v7");
 //                    busTarget.bus().get().register(Class.forName(data.clazz().getClassName(), true, loader));
-//                } catch (ClassNotFoundException e) {
-//                    LOGGER.fatal(Logging.LOADING, "Failed to load mod class {} for @EventBusSubscriber annotation", data.clazz(), e);
-//                    throw new RuntimeException(e);
-//                }
+                } catch (ClassNotFoundException e) {
+                    LOGGER.fatal(Logging.LOADING, "Failed to load mod class {} for @EventBusSubscriber annotation", data.clazz(), e);
+                    throw new RuntimeException(e);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -73,13 +73,14 @@ public class AutomaticEventSubscriber {
             var busName = value(data, "bus", defaultBus).value();
             var busTarget = Bus.valueOf(busName);
             if (Objects.equals(mod.getModId(), modId) && sides.contains(FMLEnvironment.dist)) {
-                try {
+//                try {
                     LOGGER.debug(Logging.LOADING, "Auto-subscribing {} to {}", data.clazz().getClassName(), busTarget);
-                    busTarget.bus().get().register(Class.forName(data.clazz().getClassName(), true, loader));
-                } catch (ClassNotFoundException e) {
-                    LOGGER.fatal(Logging.LOADING, "Failed to load mod class {} for @EventBusSubscriber annotation", data.clazz(), e);
-                    throw new RuntimeException(e);
-                }
+                    throw new RuntimeException("Todo: [FML][EventBusSubscriber] Adjust EventBusSubscriber to support EventBus v7");
+//                    busTarget.bus().get().register(Class.forName(data.clazz().getClassName(), true, loader));
+//                } catch (ClassNotFoundException e) {
+//                    LOGGER.fatal(Logging.LOADING, "Failed to load mod class {} for @EventBusSubscriber annotation", data.clazz(), e);
+//                    throw new RuntimeException(e);
+//                }
             }
         }
     }

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLoadingContext.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLoadingContext.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.fml.javafmlmod;
 
-import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.ModLoadingContext;
 
 /**
@@ -22,9 +22,9 @@ public class FMLJavaModLoadingContext extends ModLoadingContext
     /**
      * @return The mod's event bus, to allow subscription to Mod specific events
      */
-    public IEventBus getModEventBus()
+    public BusGroup getModEventBus()
     {
-        return container.getEventBus();
+        return container.getEventBusGroup();
     }
 
     /**

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.fml.javafmlmod;
 
 import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingException;
 import net.minecraftforge.fml.ModLoadingStage;
@@ -177,9 +178,15 @@ public class FMLModContainer extends ModContainer {
     protected <T extends IModBusEvent> void acceptEvent(final T e) {
         try {
             LOGGER.trace(LOADING, "Firing event for modid {} : {}", this.getModId(), e);
-            throw new RuntimeException("Todo: [FML][Event] Dispatch lifecycle event from the right BusGroup");
+//            throw new RuntimeException("Todo: [FML][Event] Dispatch lifecycle event from the right BusGroup");
+            // Temp code until the FML rewrite is done - do not copy! May break at any time without notice as this
+            // technically violates the API contract of EventBus#create
+            EventBus eventBus = (EventBus) EventBus.create(eventBusGroup, e.getClass());
+            eventBus.post(e);
 //            this.eventBusGroup.post(e);
 //            LOGGER.trace(LOADING, "Fired event for modid {} : {}", this.getModId(), e);
+        } catch (NoClassDefFoundError err) {
+            // lol wth?
         } catch (Throwable t) {
             LOGGER.error(LOADING,"Caught exception during event {} dispatch for modid {}", e, this.getModId(), t);
             throw new ModLoadingException(modInfo, modLoadingStage, "fml.modloading.errorduringevent", t);
@@ -188,7 +195,9 @@ public class FMLModContainer extends ModContainer {
 
     @Override
     public void dispatchConfigEvent(IConfigEvent event) {
-        throw new RuntimeException("Todo: [FML][Event] Dispatch config event from the right BusGroup");
+        EventBus eventBus = (EventBus) EventBus.create(eventBusGroup, event.self().getClass());
+        eventBus.post(event.self());
+//        throw new RuntimeException("Todo: [FML][Event] Dispatch config event from the right BusGroup");
 //        this.eventBusGroup.post(event.self());
     }
 

--- a/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/javafmllanguage/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -5,11 +5,7 @@
 
 package net.minecraftforge.fml.javafmlmod;
 
-import net.minecraftforge.eventbus.EventBusErrorMessage;
-import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.IEventListener;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingException;
 import net.minecraftforge.fml.ModLoadingStage;
@@ -36,7 +32,7 @@ public class FMLModContainer extends ModContainer {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker LOADING = MarkerManager.getMarker("LOADING");
     private final ModFileScanData scanResults;
-    private final IEventBus eventBus;
+    private final BusGroup eventBusGroup;
     private Object modInstance;
     private final Class<?> modClass;
     private final FMLJavaModLoadingContext context = new FMLJavaModLoadingContext(this);
@@ -46,7 +42,7 @@ public class FMLModContainer extends ModContainer {
         LOGGER.debug(LOADING,"Creating FMLModContainer instance for {}", className);
         this.scanResults = modFileScanResults;
         activityMap.put(ModLoadingStage.CONSTRUCT, this::constructMod);
-        this.eventBus = BusBuilder.builder().setExceptionHandler(FMLModContainer::onEventFailed).setTrackPhases(false).markerType(IModBusEvent.class).useModLauncher().build();
+        this.eventBusGroup = BusGroup.create("modBusFor" + info.getModId());// BusBuilder.builder().setExceptionHandler(FMLModContainer::onEventFailed).setTrackPhases(false).markerType(IModBusEvent.class).useModLauncher().build();
         this.contextExtension = () -> context;
         try {
             var moduleName = info.getOwningFile().moduleName();
@@ -128,9 +124,9 @@ public class FMLModContainer extends ModContainer {
         implAddExportsOrOpens.invoke(target, pkg, reader, open, /*syncVM*/true);
     }
 
-    private static void onEventFailed(IEventBus iEventBus, Event event, IEventListener[] iEventListeners, int i, Throwable throwable) {
-        LOGGER.error(new EventBusErrorMessage(event, i, iEventListeners, throwable));
-    }
+//    private static void onEventFailed(IEventBus iEventBus, Event event, IEventListener[] iEventListeners, int i, Throwable throwable) {
+//        LOGGER.error(new EventBusErrorMessage(event, i, iEventListeners, throwable));
+//    }
 
     private void constructMod() {
         try {
@@ -173,16 +169,17 @@ public class FMLModContainer extends ModContainer {
         return modInstance;
     }
 
-    public IEventBus getEventBus() {
-        return this.eventBus;
+    public BusGroup getEventBusGroup() {
+        return this.eventBusGroup;
     }
 
     @Override
-    protected <T extends Event & IModBusEvent> void acceptEvent(final T e) {
+    protected <T extends IModBusEvent> void acceptEvent(final T e) {
         try {
             LOGGER.trace(LOADING, "Firing event for modid {} : {}", this.getModId(), e);
-            this.eventBus.post(e);
-            LOGGER.trace(LOADING, "Fired event for modid {} : {}", this.getModId(), e);
+            throw new RuntimeException("Todo: [FML][Event] Dispatch lifecycle event from the right BusGroup");
+//            this.eventBusGroup.post(e);
+//            LOGGER.trace(LOADING, "Fired event for modid {} : {}", this.getModId(), e);
         } catch (Throwable t) {
             LOGGER.error(LOADING,"Caught exception during event {} dispatch for modid {}", e, this.getModId(), t);
             throw new ModLoadingException(modInfo, modLoadingStage, "fml.modloading.errorduringevent", t);
@@ -191,7 +188,8 @@ public class FMLModContainer extends ModContainer {
 
     @Override
     public void dispatchConfigEvent(IConfigEvent event) {
-        this.eventBus.post(event.self());
+        throw new RuntimeException("Todo: [FML][Event] Dispatch config event from the right BusGroup");
+//        this.eventBusGroup.post(event.self());
     }
 
     @Override

--- a/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
+++ b/lowcodelanguage/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
@@ -6,15 +6,11 @@
 package net.minecraftforge.fml.lowcodemod;
 
 import com.mojang.logging.LogUtils;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
-import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.ModFileScanData;
 import org.slf4j.Logger;
-
-import java.util.Objects;
 
 import static net.minecraftforge.fml.loading.LogMarkers.LOADING;
 

--- a/patches/minecraft/net/minecraft/client/gui/GuiGraphics.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiGraphics.java.patch
@@ -105,7 +105,7 @@
      ) {
          if (!p_282615_.isEmpty()) {
 +            var preEvent = net.minecraftforge.client.ForgeHooksClient.onRenderTooltipPre(this.tooltipStack, this, p_283230_, p_283417_, guiWidth(), guiHeight(), p_282615_, p_282675_, p_282442_);
-+            if (preEvent.isCanceled()) return;
++            if (preEvent == null) return;
              int i = 0;
              int j = p_282615_.size() == 1 ? -2 : 0;
  

--- a/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
@@ -13,7 +13,7 @@
          this.width = p_96608_;
          this.height = p_96609_;
          if (!this.initialized) {
-+            if (!net.minecraftforge.client.event.ScreenEvent.Init.Pre.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget))) return;
++            if (!net.minecraftforge.client.event.ScreenEvent.Init.Pre.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget)))
              this.init();
              this.setInitialFocus();
 +            net.minecraftforge.client.event.ScreenEvent.Init.Post.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Post(this, this.children, this::addEventWidget, this::removeWidget));

--- a/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
@@ -13,10 +13,10 @@
          this.width = p_96608_;
          this.height = p_96609_;
          if (!this.initialized) {
-+            if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget)))
++            if (!new net.minecraftforge.client.event.ScreenEvent.Init.Pre.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget))) return;
              this.init();
              this.setInitialFocus();
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Post(this, this.children, this::addEventWidget, this::removeWidget));
++            net.minecraftforge.client.event.ScreenEvent.Init.Post.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Post(this, this.children, this::addEventWidget, this::removeWidget));
          } else {
              this.repositionElements();
          }
@@ -24,10 +24,10 @@
      protected void rebuildWidgets() {
          this.clearWidgets();
          this.clearFocus();
-+        if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget)))
++        if (!net.minecraftforge.client.event.ScreenEvent.Init.Pre.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget)))
          this.init();
          this.setInitialFocus();
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Post(this, this.children, this::addEventWidget, this::removeWidget));
++        net.minecraftforge.client.event.ScreenEvent.Init.Post.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Post(this, this.children, this::addEventWidget, this::removeWidget));
      }
  
      @Override

--- a/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/Screen.java.patch
@@ -13,7 +13,7 @@
          this.width = p_96608_;
          this.height = p_96609_;
          if (!this.initialized) {
-+            if (!new net.minecraftforge.client.event.ScreenEvent.Init.Pre.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget))) return;
++            if (!net.minecraftforge.client.event.ScreenEvent.Init.Pre.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Pre(this, this.children, this::addEventWidget, this::removeWidget))) return;
              this.init();
              this.setInitialFocus();
 +            net.minecraftforge.client.event.ScreenEvent.Init.Post.BUS.post(new net.minecraftforge.client.event.ScreenEvent.Init.Post(this, this.children, this::addEventWidget, this::removeWidget));

--- a/patches/minecraft/net/minecraft/client/gui/screens/inventory/EffectsInInventory.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/inventory/EffectsInInventory.java.patch
@@ -5,7 +5,7 @@
          if (!collection.isEmpty() && j >= 32) {
              boolean flag = j >= 120;
 +            var event = net.minecraftforge.client.event.ForgeEventFactoryClient.onScreenEffectSize(this.screen, j, !flag, i);
-+            if (event.isCanceled()) return;
++            if (event == null) return;
 +            flag = !event.isCompact();
 +            i = event.getHorizontalOffset();
              int k = 33;

--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientChunkCache.java.patch
@@ -4,7 +4,7 @@
              int i = this.storage.getIndex(p_298665_.x, p_298665_.z);
              LevelChunk levelchunk = this.storage.getChunk(i);
              if (isValidChunk(levelchunk, p_298665_.x, p_298665_.z)) {
-+                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Unload(levelchunk));
++                net.minecraftforge.event.level.ChunkEvent.Unload.BUS.post(new net.minecraftforge.event.level.ChunkEvent.Unload(levelchunk));
                  this.storage.drop(i, levelchunk);
              }
          }
@@ -12,7 +12,7 @@
              }
  
              this.level.onChunkLoaded(chunkpos);
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk, false));
++            net.minecraftforge.event.level.ChunkEvent.Load.BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk, false));
              return levelchunk;
          }
      }

--- a/patches/minecraft/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -50,7 +50,7 @@
          long p_263408_
      ) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtPosition(this, p_263372_, p_263404_, p_263365_, p_263335_, p_263417_, p_263416_, p_263349_);
-+        if (event.isCanceled() || event.getSound() == null) return;
++        if (event == null || event.getSound() == null) return;
 +        p_263335_ = event.getSound();
 +        p_263417_ = event.getSource();
 +        p_263416_ = event.getNewVolume();
@@ -63,7 +63,7 @@
          @Nullable Player p_263514_, Entity p_263536_, Holder<SoundEvent> p_263518_, SoundSource p_263487_, float p_263538_, float p_263524_, long p_263509_
      ) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_263536_, p_263518_, p_263487_, p_263538_, p_263524_);
-+        if (event.isCanceled() || event.getSound() == null) return;
++        if (event == null || event.getSound() == null) return;
 +        p_263518_ = event.getSound();
 +        p_263487_ = event.getSource();
 +        p_263538_ = event.getNewVolume();

--- a/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -38,11 +38,11 @@
                  this.startPrediction(this.minecraft.level, p_233728_ -> {
                      boolean flag = !blockstate1.isAir();
                      if (flag && this.destroyProgress == 0.0F) {
-+                        if (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY)
++                        if (event.getUseBlock() != net.minecraftforge.common.util.Result.DENY)
                          blockstate1.attack(this.minecraft.level, p_105270_, this.minecraft.player);
                      }
  
-+                    if (event.getUseItem() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
++                    if (event.getUseItem() != net.minecraftforge.common.util.Result.DENY) {
                      if (flag && blockstate1.getDestroyProgress(this.minecraft.player, this.minecraft.player.level(), p_105270_) >= 1.0F) {
                          this.destroyBlock(p_105270_);
                      } else {
@@ -75,7 +75,7 @@
  
                  this.destroyTicks++;
                  this.minecraft.getTutorial().onDestroyBlock(this.minecraft.level, p_105284_, blockstate, Mth.clamp(this.destroyProgress, 0.0F, 1.0F));
-+                if (net.minecraftforge.event.ForgeEventFactory.onLeftClickBlockHold(this.minecraft.player, p_105284_, p_105285_).getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return true;
++                if (net.minecraftforge.event.ForgeEventFactory.onLeftClickBlockHold(this.minecraft.player, p_105284_, p_105285_).getUseItem() == net.minecraftforge.common.util.Result.DENY) return true;
                  if (this.destroyProgress >= 1.0F) {
                      this.isDestroying = false;
                      this.startPrediction(this.minecraft.level, p_233739_ -> {
@@ -101,7 +101,7 @@
          } else {
 -            boolean flag = !p_233747_.getMainHandItem().isEmpty() || !p_233747_.getOffhandItem().isEmpty();
 +            UseOnContext useoncontext = new UseOnContext(p_233747_, p_233748_, p_233749_);
-+            if (event.getUseItem() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
++            if (event.getUseItem() != net.minecraftforge.common.util.Result.DENY) {
 +               InteractionResult result = itemstack.onItemUseFirst(useoncontext);
 +               if (result != InteractionResult.PASS) {
 +                  return result;
@@ -110,7 +110,7 @@
 +            boolean flag = !p_233747_.getMainHandItem().doesSneakBypassUse(p_233747_.level(), blockpos, p_233747_) || !p_233747_.getOffhandItem().doesSneakBypassUse(p_233747_.level(), blockpos, p_233747_);
              boolean flag1 = p_233747_.isSecondaryUseActive() && flag;
 -            if (!flag1) {
-+            if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1)) {
++            if (event.getUseBlock() == net.minecraftforge.common.util.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.common.util.Result.DENY && !flag1)) {
                  BlockState blockstate = this.minecraft.level.getBlockState(blockpos);
                  if (!this.connection.isFeatureEnabled(blockstate.getBlock().requiredFeatures())) {
                      return InteractionResult.FAIL;
@@ -120,10 +120,10 @@
  
 -            if (!itemstack.isEmpty() && !p_233747_.getCooldowns().isOnCooldown(itemstack)) {
 -                UseOnContext useoncontext = new UseOnContext(p_233747_, p_233748_, p_233749_);
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) {
++            if (event.getUseItem() == net.minecraftforge.common.util.Result.DENY) {
 +               return InteractionResult.PASS;
 +            }
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!itemstack.isEmpty() && !p_233747_.getCooldowns().isOnCooldown(itemstack))) {
++            if (event.getUseItem() == net.minecraftforge.common.util.Result.ALLOW || (!itemstack.isEmpty() && !p_233747_.getCooldowns().isOnCooldown(itemstack))) {
                  InteractionResult interactionresult2;
                  if (this.localPlayerMode.isCreative()) {
                      int i = itemstack.getCount();

--- a/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/player/LocalPlayer.java.patch
@@ -15,7 +15,7 @@
 -        this.level().playLocalSound(this.getX(), this.getY(), this.getZ(), p_108651_, this.getSoundSource(), p_108652_, p_108653_, false);
 +        var holder = net.minecraft.core.registries.BuiltInRegistries.SOUND_EVENT.wrapAsHolder(p_108651_);
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(this, holder, this.getSoundSource(), p_108652_, p_108653_);
-+        if (event.isCanceled() || event.getSound() == null) return;
++        if (event == null || event.getSound() == null) return;
 +        this.level().playLocalSound(this.getX(), this.getY(), this.getZ(), event.getSound().get(), event.getSource(), event.getNewVolume(), event.getNewPitch(), false);
 +
      }

--- a/patches/minecraft/net/minecraft/commands/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/commands/Commands.java.patch
@@ -25,7 +25,7 @@
  
          try {
 +            var event = new net.minecraftforge.event.CommandEvent(p_242844_);
-+            if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) {
++            if (!net.minecraftforge.event.CommandEvent.BUS.post(event)) { // TODO [MANGO]: Might not be !, perhaps we are checking it is cancelled vs not cancelled?
 +                if (event.getException() instanceof Exception exception) {
 +                    throw exception;
 +                } else if (event.getException() != null) {

--- a/patches/minecraft/net/minecraft/commands/Commands.java.patch
+++ b/patches/minecraft/net/minecraft/commands/Commands.java.patch
@@ -25,7 +25,7 @@
  
          try {
 +            var event = new net.minecraftforge.event.CommandEvent(p_242844_);
-+            if (!net.minecraftforge.event.CommandEvent.BUS.post(event)) { // TODO [MANGO]: Might not be !, perhaps we are checking it is cancelled vs not cancelled?
++            if (net.minecraftforge.event.CommandEvent.BUS.post(event)) { // TODO [MANGO]: Might not be !, perhaps we are checking it is cancelled vs not cancelled?
 +                if (event.getException() instanceof Exception exception) {
 +                    throw exception;
 +                } else if (event.getException() != null) {

--- a/patches/minecraft/net/minecraft/server/commands/SpreadPlayersCommand.java.patch
+++ b/patches/minecraft/net/minecraft/server/commands/SpreadPlayersCommand.java.patch
@@ -9,7 +9,7 @@
 +                (double)spreadplayerscommand$position.getSpawnY(p_138731_, p_138733_),
 +                (double)Mth.floor(spreadplayerscommand$position.z) + 0.5D
 +            );
-+            if (!event.isCanceled())
++            if (event != null)
              entity.teleportTo(
                  p_138731_,
 -                (double)Mth.floor(spreadplayerscommand$position.x) + 0.5,

--- a/patches/minecraft/net/minecraft/server/commands/TeleportCommand.java.patch
+++ b/patches/minecraft/net/minecraft/server/commands/TeleportCommand.java.patch
@@ -5,7 +5,7 @@
          @Nullable LookAt p_365991_
      ) throws CommandSyntaxException {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onEntityTeleportCommand(p_139016_, p_139018_, p_139019_, p_139020_);
-+        if (event.isCanceled()) return;
++        if (event == null) return;
 +        p_139018_ = event.getTargetX(); p_139019_ = event.getTargetY(); p_139020_ = event.getTargetZ();
          BlockPos blockpos = BlockPos.containing(p_139018_, p_139019_, p_139020_);
          if (!Level.isInSpawnableBounds(blockpos)) {

--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -63,7 +63,7 @@
  
      @Override
      public void stopServer() {
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.GameShuttingDownEvent());
++        net.minecraftforge.event.GameShuttingDownEvent.BUS.post(new net.minecraftforge.event.GameShuttingDownEvent());
          super.stopServer();
 +        if (this.dediLanPinger != null) {
 +            this.dediLanPinger.interrupt();

--- a/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerLevel.java.patch
@@ -135,7 +135,7 @@
          long p_263403_
      ) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtPosition(this, p_263393_, p_263369_, p_263354_, p_263412_, p_263338_, p_263352_, p_263390_);
-+        if (event.isCanceled() || event.getSound() == null) return;
++        if (event == null || event.getSound() == null) return;
 +        p_263412_ = event.getSound();
 +        p_263338_ = event.getSource();
 +        p_263352_ = event.getNewVolume();
@@ -148,7 +148,7 @@
          @Nullable Player p_263545_, Entity p_263544_, Holder<SoundEvent> p_263491_, SoundSource p_263542_, float p_263530_, float p_263520_, long p_263490_
      ) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAtEntity(p_263544_, p_263491_, p_263542_, p_263530_, p_263520_);
-+        if (event.isCanceled() || event.getSound() == null) return;
++        if (event == null || event.getSound() == null) return;
 +        p_263491_ = event.getSound();
 +        p_263542_ = event.getSource();
 +        p_263530_ = event.getNewVolume();

--- a/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -15,7 +15,7 @@
                  float f = 1.0F;
                  BlockState blockstate = this.level.getBlockState(p_215120_);
                  if (!blockstate.isAir()) {
-+                    if (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
++                    if (event.getUseBlock() != net.minecraftforge.common.util.Result.DENY) {
                      EnchantmentHelper.onHitBlock(
                          this.level,
                          this.player.getMainHandItem(),
@@ -118,7 +118,7 @@
              }
          } else {
 +            UseOnContext useoncontext = new UseOnContext(p_9266_, p_9269_, p_9270_);
-+            if (event.getUseItem() != net.minecraftforge.eventbus.api.Event.Result.DENY) {
++            if (event.getUseItem() != net.minecraftforge.common.util.Result.DENY) {
 +                InteractionResult result = p_9268_.onItemUseFirst(useoncontext);
 +                if (result != InteractionResult.PASS) return result;
 +            }
@@ -127,7 +127,7 @@
 +            flag1 &= !(p_9266_.getMainHandItem().doesSneakBypassUse(p_9267_, blockpos, p_9266_) && p_9266_.getOffhandItem().doesSneakBypassUse(p_9267_, blockpos, p_9266_));
              ItemStack itemstack = p_9268_.copy();
 -            if (!flag1) {
-+            if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.eventbus.api.Event.Result.DENY && !flag1)) {
++            if (event.getUseBlock() == net.minecraftforge.common.util.Result.ALLOW || (event.getUseBlock() != net.minecraftforge.common.util.Result.DENY && !flag1)) {
                  InteractionResult interactionresult = blockstate.useItemOn(p_9266_.getItemInHand(p_9269_), p_9267_, p_9266_, p_9269_, p_9270_);
                  if (interactionresult.consumesAction()) {
                      CriteriaTriggers.ITEM_USED_ON_BLOCK.trigger(p_9266_, blockpos, itemstack);
@@ -137,8 +137,8 @@
  
 -            if (!p_9268_.isEmpty() && !p_9266_.getCooldowns().isOnCooldown(p_9268_)) {
 -                UseOnContext useoncontext = new UseOnContext(p_9266_, p_9269_, p_9270_);
-+            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.ALLOW || (!p_9268_.isEmpty() && !p_9266_.getCooldowns().isOnCooldown(p_9268_))) {
-+                if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return InteractionResult.PASS;
++            if (event.getUseItem() == net.minecraftforge.common.util.Result.ALLOW || (!p_9268_.isEmpty() && !p_9266_.getCooldowns().isOnCooldown(p_9268_))) {
++                if (event.getUseItem() == net.minecraftforge.common.util.Result.DENY) return InteractionResult.PASS;
                  InteractionResult interactionresult2;
                  if (this.isCreative()) {
                      int i = p_9268_.getCount();

--- a/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -8,7 +8,7 @@
 -                        this.player.setItemInHand(InteractionHand.OFF_HAND, this.player.getItemInHand(InteractionHand.MAIN_HAND));
 -                        this.player.setItemInHand(InteractionHand.MAIN_HAND, itemstack);
 +                        var event = net.minecraftforge.event.ForgeEventFactory.onLivingSwapHandItems(this.player);
-+                        if (event.isCanceled()) return;
++                        if (event == null) return;
 +                        this.player.setItemInHand(InteractionHand.OFF_HAND, event.getItemSwappedToOffHand());
 +                        this.player.setItemInHand(InteractionHand.MAIN_HAND, event.getItemSwappedToMainHand());
                          this.player.stopUsingItem();

--- a/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/players/PlayerList.java.patch
@@ -12,7 +12,7 @@
          servergamepacketlistenerimpl.send(new ClientboundPlayerAbilitiesPacket(p_11263_.getAbilities()));
          servergamepacketlistenerimpl.send(new ClientboundSetHeldSlotPacket(p_11263_.getInventory().selected));
          RecipeManager recipemanager = this.server.getRecipeManager();
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, p_11263_));
++        net.minecraftforge.event.OnDatapackSyncEvent.BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, p_11263_));
          servergamepacketlistenerimpl.send(new ClientboundUpdateRecipesPacket(recipemanager.getSynchronizedItemProperties(), recipemanager.getSynchronizedStonecutterRecipes()));
          this.sendPlayerPermissionLevel(p_11263_);
          p_11263_.getStats().markAllDirty();
@@ -99,7 +99,7 @@
              playeradvancements.reload(this.server.getAdvancements());
          }
  
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, null));
++        net.minecraftforge.event.OnDatapackSyncEvent.BUS.post(new net.minecraftforge.event.OnDatapackSyncEvent(this, null));
          this.broadcastAll(new ClientboundUpdateTagsPacket(TagNetworkSerialization.serializeTagsToNetwork(this.registries)));
          RecipeManager recipemanager = this.server.getRecipeManager();
          ClientboundUpdateRecipesPacket clientboundupdaterecipespacket = new ClientboundUpdateRecipesPacket(recipemanager.getSynchronizedItemProperties(), recipemanager.getSynchronizedStonecutterRecipes());

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -28,14 +28,6 @@
      private final Set<TagKey<Fluid>> fluidOnEyes = new HashSet<>();
      public int invulnerableTime;
      protected boolean firstTick = true;
-@@ -251,6 +_,7 @@
-     private final LongSet visitedBlocks = new LongOpenHashSet();
- 
-     public Entity(EntityType<?> p_19870_, Level p_19871_) {
-+        super(Entity.class);
-         this.type = p_19870_;
-         this.level = p_19871_;
-         this.dimensions = p_19870_.getDimensions();
 @@ -270,6 +_,8 @@
          this.entityData = synchedentitydata$builder.build();
          this.setPos(0.0, 0.0, 0.0);
@@ -451,12 +443,10 @@
      }
  
      public void checkDespawn() {
-@@ -3672,6 +_,100 @@
-         float f1 = (float)Mth.lerp(d0, (double)this.getXRot(), p_298926_);
-         this.setPos(d1, d2, d3);
+@@ -3674,6 +_,100 @@
          this.setRot(f, f1);
-+    }
-+
+     }
+ 
 +    private boolean canUpdate = true;
 +    @Override
 +    public void canUpdate(boolean value) {
@@ -549,6 +539,19 @@
 +    @Override
 +    public net.minecraftforge.fluids.FluidType getMaxHeightFluidType() {
 +        return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.minecraftforge.common.ForgeMod.EMPTY_TYPE);
-     }
- 
++    }
++
      public RandomSource getRandom() {
+         return this.random;
+     }
+@@ -3753,4 +_,10 @@
+             return this.save;
+         }
+     }
++
++    // FORGE START
++    protected final net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(Entity provider) {
++        return net.minecraftforge.event.AttachCapabilitiesEvent.EntityEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.EntityEvent(provider));
++    }
++    // FORGE END
+ }

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -28,6 +28,14 @@
      private final Set<TagKey<Fluid>> fluidOnEyes = new HashSet<>();
      public int invulnerableTime;
      protected boolean firstTick = true;
+@@ -251,6 +_,7 @@
+     private final LongSet visitedBlocks = new LongOpenHashSet();
+ 
+     public Entity(EntityType<?> p_19870_, Level p_19871_) {
++        super(Entity.class);
+         this.type = p_19870_;
+         this.level = p_19871_;
+         this.dimensions = p_19870_.getDimensions();
 @@ -270,6 +_,8 @@
          this.entityData = synchedentitydata$builder.build();
          this.setPos(0.0, 0.0, 0.0);
@@ -443,10 +451,12 @@
      }
  
      public void checkDespawn() {
-@@ -3674,6 +_,100 @@
+@@ -3672,6 +_,100 @@
+         float f1 = (float)Mth.lerp(d0, (double)this.getXRot(), p_298926_);
+         this.setPos(d1, d2, d3);
          this.setRot(f, f1);
-     }
- 
++    }
++
 +    private boolean canUpdate = true;
 +    @Override
 +    public void canUpdate(boolean value) {
@@ -539,19 +549,6 @@
 +    @Override
 +    public net.minecraftforge.fluids.FluidType getMaxHeightFluidType() {
 +        return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.minecraftforge.common.ForgeMod.EMPTY_TYPE);
-+    }
-+
+     }
+ 
      public RandomSource getRandom() {
-         return this.random;
-     }
-@@ -3753,4 +_,10 @@
-             return this.save;
-         }
-     }
-+
-+    // FORGE START
-+    protected final net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(Entity provider) {
-+        return net.minecraftforge.event.AttachCapabilitiesEvent.EntityEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.EntityEvent(provider));
-+    }
-+    // FORGE END
- }

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -268,7 +268,7 @@
  
      public void knockback(double p_147241_, double p_147242_, double p_147243_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLivingKnockBack(this, (float) p_147241_, p_147242_, p_147243_);
-+        if (event.isCanceled()) return;
++        if (event == null) return;
 +        p_147241_ = event.getStrength();
 +        p_147242_ = event.getRatioX();
 +        p_147243_ = event.getRatioZ();
@@ -294,7 +294,7 @@
      @Override
      public boolean causeFallDamage(float p_147187_, float p_147188_, DamageSource p_147189_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLivingFall(this, p_147187_, p_147188_);
-+        if (event.isCanceled()) return false;
++        if (event == null) return false;
 +        p_147187_ = event.getDistance();
 +        p_147188_ = event.getDamageMultiplier();
          boolean flag = super.causeFallDamage(p_147187_, p_147188_, p_147189_);
@@ -359,7 +359,7 @@
 -        this.setItemSlot(EquipmentSlot.OFFHAND, this.getItemBySlot(EquipmentSlot.MAINHAND));
 -        this.setItemSlot(EquipmentSlot.MAINHAND, itemstack);
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLivingSwapHandItems(this);
-+        if (event.isCanceled()) return;
++        if (event == null) return;
 +        this.setItemSlot(EquipmentSlot.OFFHAND, event.getItemSwappedToOffHand());
 +        this.setItemSlot(EquipmentSlot.MAINHAND, event.getItemSwappedToMainHand());
      }

--- a/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Mob.java.patch
@@ -16,7 +16,7 @@
      public void setTarget(@Nullable LivingEntity p_21544_) {
 -        this.target = p_21544_;
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLivingChangeTargetMob(this, p_21544_);
-+        if (!event.isCanceled()) {
++        if (event != null) {
 +            this.target = event.getNewTarget();
 +        }
      }
@@ -62,10 +62,10 @@
          } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
              Entity entity = this.level().getNearestPlayer(this, -1.0);
 +            var result = net.minecraftforge.event.ForgeEventFactory.canEntityDespawn(this, (ServerLevel)this.level());
-+            if (result == net.minecraftforge.eventbus.api.Event.Result.DENY) {
++            if (result == net.minecraftforge.common.util.Result.DENY) {
 +                noActionTime = 0;
 +                entity = null;
-+            } else if (result == net.minecraftforge.eventbus.api.Event.Result.ALLOW) {
++            } else if (result == net.minecraftforge.common.util.Result.ALLOW) {
 +                this.discard();
 +                entity = null;
 +            }

--- a/patches/minecraft/net/minecraft/world/entity/ai/behavior/StartAttacking.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/behavior/StartAttacking.java.patch
@@ -6,7 +6,7 @@
                                      } else {
 -                                        p_258778_.set(livingentity);
 +                                        var changeTargetEvent = net.minecraftforge.event.ForgeEventFactory.onLivingChangeTargetBehavior(p_359049_, livingentity);
-+                                        if (changeTargetEvent.isCanceled())
++                                        if (changeTargetEvent == null)
 +                                            return false;
 +
 +                                        p_258778_.set(changeTargetEvent.getNewTarget());

--- a/patches/minecraft/net/minecraft/world/entity/ai/village/VillageSiege.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/ai/village/VillageSiege.java.patch
@@ -7,7 +7,7 @@
 -                        if (this.findRandomSpawnPos(p_27008_, new BlockPos(this.spawnX, this.spawnY, this.spawnZ)) != null) {
 +                        Vec3 siegeLocation = this.findRandomSpawnPos(p_27008_, new BlockPos(this.spawnX, this.spawnY, this.spawnZ));
 +                        if (siegeLocation != null) {
-+                            if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.village.VillageSiegeEvent(this, p_27008_, player, siegeLocation)))
++                            if (net.minecraftforge.event.village.VillageSiegeEvent.BUS.post(new net.minecraftforge.event.village.VillageSiegeEvent(this, p_27008_, player, siegeLocation)))
 +                                return false;
                              this.nextSpawnTime = 0;
                              this.zombiesToSpawn = 20;

--- a/patches/minecraft/net/minecraft/world/entity/animal/Animal.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/Animal.java.patch
@@ -5,7 +5,7 @@
      public void spawnChildFromBreeding(ServerLevel p_27564_, Animal p_27565_) {
          AgeableMob ageablemob = this.getBreedOffspring(p_27564_, p_27565_);
 +        final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(this, p_27565_, ageablemob);
-+        final boolean cancelled = net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
++        final boolean cancelled = net.minecraftforge.event.entity.living.BabyEntitySpawnEvent.BUS.post(event);
 +        ageablemob = event.getChild();
 +        if (cancelled) {
 +            //Reset the "inLove" state for the animals

--- a/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -5,7 +5,7 @@
      @Override
      public boolean causeFallDamage(float p_149499_, float p_149500_, DamageSource p_149501_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLivingFall(this, p_149499_, p_149500_);
-+        if (event.isCanceled()) return false;
++        if (event == null) return false;
 +        p_149499_ = event.getDistance();
 +        p_149500_ = event.getDamageMultiplier();
 +

--- a/patches/minecraft/net/minecraft/world/entity/animal/horse/Llama.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/horse/Llama.java.patch
@@ -5,7 +5,7 @@
      @Override
      public boolean causeFallDamage(float p_149538_, float p_149539_, DamageSource p_149540_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onLivingFall(this, p_149538_, p_149539_);
-+        if (event.isCanceled()) return false;
++        if (event == null) return false;
 +        p_149538_ = event.getDistance();
 +        p_149539_ = event.getDamageMultiplier();
          int i = this.calculateFallDamage(p_149538_, p_149539_);

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -293,7 +293,7 @@
  
      public void giveExperiencePoints(int p_36291_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlayerXpChange(this, p_36291_);
-+        if (event.isCanceled()) {
++        if (event == null) {
 +            return;
 +        }
 +        p_36291_ = event.getAmount();
@@ -315,7 +315,7 @@
  
      public void giveExperienceLevels(int p_36276_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onPlayerLevelChange(this, p_36276_);
-+        if (event.isCanceled()) {
++        if (event == null) {
 +            return;
 +        }
 +        p_36276_ = event.getLevels();

--- a/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/minecraft/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -45,7 +45,7 @@
  
      private ItemStack computeResult(ItemStack p_335167_, ItemStack p_329934_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onGrindstoneChange(p_335167_, p_329934_, this.resultSlots, -1);
-+        if (event.isCanceled()) {
++        if (event == null) {
 +            this.xp = -1;
 +            return ItemStack.EMPTY;
 +        } else if (!event.getOutput().isEmpty()) {

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -13,7 +13,7 @@
      }
  
      private ItemStack(ItemLike p_331826_, int p_332766_, PatchedDataComponentMap p_333722_) {
-+        super(ItemStack.class, true);
++        super(true);
          this.item = p_331826_.asItem();
          this.count = p_332766_;
          this.components = p_333722_;
@@ -22,7 +22,7 @@
      }
  
      private ItemStack(@Nullable Void p_282703_) {
-+        super(ItemStack.class, false);
++        super(false);
          this.item = null;
          this.components = new PatchedDataComponentMap(DataComponentMap.EMPTY);
      }
@@ -110,3 +110,14 @@
      public void onDestroyed(ItemEntity p_150925_) {
          this.getItem().onDestroyed(p_150925_);
      }
+@@ -1119,4 +_,10 @@
+         Repairable repairable = this.get(DataComponents.REPAIRABLE);
+         return repairable != null && repairable.isValidRepairItem(p_368140_);
+     }
++
++    // FORGE START
++    protected net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(ItemStack provider) {
++        return net.minecraftforge.event.AttachCapabilitiesEvent.ItemStackEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.ItemStackEvent(provider));
++    }
++    // FORGE END
+ }

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -13,7 +13,7 @@
      }
  
      private ItemStack(ItemLike p_331826_, int p_332766_, PatchedDataComponentMap p_333722_) {
-+        super(true);
++        super(ItemStack.class, true);
          this.item = p_331826_.asItem();
          this.count = p_332766_;
          this.components = p_333722_;
@@ -22,7 +22,7 @@
      }
  
      private ItemStack(@Nullable Void p_282703_) {
-+        super(false);
++        super(ItemStack.class, false);
          this.item = null;
          this.components = new PatchedDataComponentMap(DataComponentMap.EMPTY);
      }
@@ -110,14 +110,3 @@
      public void onDestroyed(ItemEntity p_150925_) {
          this.getItem().onDestroyed(p_150925_);
      }
-@@ -1119,4 +_,10 @@
-         Repairable repairable = this.get(DataComponents.REPAIRABLE);
-         return repairable != null && repairable.isValidRepairItem(p_368140_);
-     }
-+
-+    // FORGE START
-+    protected net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(ItemStack provider) {
-+        return net.minecraftforge.event.AttachCapabilitiesEvent.ItemStackEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.ItemStackEvent(provider));
-+    }
-+    // FORGE END
- }

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -21,6 +21,14 @@
  
      protected Level(
          WritableLevelData p_270739_,
+@@ -127,6 +_,7 @@
+         long p_270248_,
+         int p_270466_
+     ) {
++        super(Level.class);
+         this.levelData = p_270739_;
+         this.dimensionTypeRegistration = p_270240_;
+         final DimensionType dimensiontype = p_270240_.value();
 @@ -216,11 +_,35 @@
          } else {
              LevelChunk levelchunk = this.getChunkAt(p_46605_);
@@ -173,10 +181,11 @@
                      }
                  }
              }
-@@ -1045,6 +_,20 @@
+@@ -1044,6 +_,20 @@
+     }
  
      public abstract PotionBrewing potionBrewing();
- 
++
 +    private double maxEntityRadius = 2.0D;
 +
 +    @Override
@@ -190,18 +199,6 @@
 +          maxEntityRadius = value;
 +       return maxEntityRadius;
 +    }
-+
+ 
      public abstract FuelValues fuelValues();
  
-     public static enum ExplosionInteraction implements StringRepresentable {
-@@ -1066,4 +_,10 @@
-             return this.id;
-         }
-     }
-+
-+    // FORGE START
-+    protected final net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(Level provider) {
-+        return net.minecraftforge.event.AttachCapabilitiesEvent.LevelEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.LevelEvent(provider));
-+    }
-+    // FORGE END
- }

--- a/patches/minecraft/net/minecraft/world/level/Level.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/Level.java.patch
@@ -21,14 +21,6 @@
  
      protected Level(
          WritableLevelData p_270739_,
-@@ -127,6 +_,7 @@
-         long p_270248_,
-         int p_270466_
-     ) {
-+        super(Level.class);
-         this.levelData = p_270739_;
-         this.dimensionTypeRegistration = p_270240_;
-         final DimensionType dimensiontype = p_270240_.value();
 @@ -216,11 +_,35 @@
          } else {
              LevelChunk levelchunk = this.getChunkAt(p_46605_);
@@ -181,11 +173,10 @@
                      }
                  }
              }
-@@ -1044,6 +_,20 @@
-     }
+@@ -1045,6 +_,20 @@
  
      public abstract PotionBrewing potionBrewing();
-+
+ 
 +    private double maxEntityRadius = 2.0D;
 +
 +    @Override
@@ -199,6 +190,18 @@
 +          maxEntityRadius = value;
 +       return maxEntityRadius;
 +    }
- 
++
      public abstract FuelValues fuelValues();
  
+     public static enum ExplosionInteraction implements StringRepresentable {
+@@ -1066,4 +_,10 @@
+             return this.id;
+         }
+     }
++
++    // FORGE START
++    protected final net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(Level provider) {
++        return net.minecraftforge.event.AttachCapabilitiesEvent.LevelEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.LevelEvent(provider));
++    }
++    // FORGE END
+ }

--- a/patches/minecraft/net/minecraft/world/level/block/NoteBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/NoteBlock.java.patch
@@ -16,7 +16,7 @@
      @Override
      protected boolean triggerEvent(BlockState p_55023_, Level p_55024_, BlockPos p_55025_, int p_55026_, int p_55027_) {
 +        var event = net.minecraftforge.event.ForgeEventFactory.onNotePlay(p_55024_, p_55025_, p_55023_, p_55023_.getValue(NOTE), p_55023_.getValue(INSTRUMENT));
-+        if (event.isCanceled()) return false;
++        if (event == null) return false;
 +        p_55023_ = p_55023_.setValue(NOTE, event.getVanillaNoteId()).setValue(INSTRUMENT, event.getInstrument());
          NoteBlockInstrument noteblockinstrument = p_55023_.getValue(INSTRUMENT);
          float f;

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -9,7 +9,12 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      private final BlockEntityType<?> type;
      @Nullable
-@@ -41,6 +_,7 @@
+@@ -37,10 +_,12 @@
+     private DataComponentMap components = DataComponentMap.EMPTY;
+ 
+     public BlockEntity(BlockEntityType<?> p_155228_, BlockPos p_155229_, BlockState p_155230_) {
++        super(BlockEntity.class);
+         this.type = p_155228_;
          this.worldPosition = p_155229_.immutable();
          this.validateBlockState(p_155230_);
          this.blockState = p_155230_;
@@ -56,14 +61,3 @@
      }
  
      public void clearRemoved() {
-@@ -315,4 +_,10 @@
- 
-         <T> T getOrDefault(DataComponentType<? extends T> p_330702_, T p_330858_);
-     }
-+
-+    // FORGE START
-+    protected final net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(BlockEntity provider) {
-+        return net.minecraftforge.event.AttachCapabilitiesEvent.BlockEntityEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.BlockEntityEvent(provider));
-+    }
-+    // FORGE END
- }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -9,12 +9,7 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      private final BlockEntityType<?> type;
      @Nullable
-@@ -37,10 +_,12 @@
-     private DataComponentMap components = DataComponentMap.EMPTY;
- 
-     public BlockEntity(BlockEntityType<?> p_155228_, BlockPos p_155229_, BlockState p_155230_) {
-+        super(BlockEntity.class);
-         this.type = p_155228_;
+@@ -41,6 +_,7 @@
          this.worldPosition = p_155229_.immutable();
          this.validateBlockState(p_155230_);
          this.blockState = p_155230_;
@@ -61,3 +56,14 @@
      }
  
      public void clearRemoved() {
+@@ -315,4 +_,10 @@
+ 
+         <T> T getOrDefault(DataComponentType<? extends T> p_330702_, T p_330858_);
+     }
++
++    // FORGE START
++    protected final net.minecraftforge.event.AttachCapabilitiesEvent<?> postEvent(BlockEntity provider) {
++        return net.minecraftforge.event.AttachCapabilitiesEvent.BlockEntityEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.BlockEntityEvent(provider));
++    }
++    // FORGE END
+ }

--- a/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -109,7 +109,7 @@
          return new LevelChunk.BoundTickingBlockEntity<>(p_156376_, p_156377_);
      }
  
-+    private final net.minecraftforge.common.capabilities.CapabilityProvider.AsField<LevelChunk> capProvider = new net.minecraftforge.common.capabilities.CapabilityProvider.AsField<>(p -> net.minecraftforge.event.AttachCapabilitiesEvent.LevelChunkEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.LevelChunkEvent(p)), this);
++    private final net.minecraftforge.common.capabilities.CapabilityProvider.AsField<LevelChunk> capProvider = new net.minecraftforge.common.capabilities.CapabilityProvider.AsField<>(LevelChunk.class, this);
 +
 +    @org.jetbrains.annotations.NotNull
 +    @Override

--- a/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -109,7 +109,7 @@
          return new LevelChunk.BoundTickingBlockEntity<>(p_156376_, p_156377_);
      }
  
-+    private final net.minecraftforge.common.capabilities.CapabilityProvider.AsField<LevelChunk> capProvider = new net.minecraftforge.common.capabilities.CapabilityProvider.AsField<>(LevelChunk.class, this);
++    private final net.minecraftforge.common.capabilities.CapabilityProvider.AsField<LevelChunk> capProvider = new net.minecraftforge.common.capabilities.CapabilityProvider.AsField<>(p -> net.minecraftforge.event.AttachCapabilitiesEvent.LevelChunkEvent.BUS.fire(new net.minecraftforge.event.AttachCapabilitiesEvent.LevelChunkEvent(p)), this);
 +
 +    @org.jetbrains.annotations.NotNull
 +    @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:6.2.27')
+            library('eventbus', 'net.minecraftforge:eventbus:7.0.0-beta.0')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             library('accesstransformers', 'net.minecraftforge:accesstransformers:8.2.2')
             library('coremods', 'net.minecraftforge:coremods:5.2.6')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            library('eventbus', 'net.minecraftforge:eventbus:7.0.0-beta.0')
+            library('eventbus', 'net.minecraftforge:eventbus:7.0-beta.1')
             library('typetools', 'net.jodah:typetools:0.6.3') // Needed by EventBus because of lambdas
             library('mergetool-api', 'net.minecraftforge:mergetool-api:1.0')
 

--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -39,7 +39,7 @@ public class ClientCommandHandler {
     private static CommandDispatcher<CommandSourceStack> commands = null;
 
     public static void init() {
-        MinecraftForge.EVENT_BUS.addListener(ClientCommandHandler::handleClientPlayerLogin);
+        ClientPlayerNetworkEvent.LoggingIn.BUS.addListener(ClientCommandHandler::handleClientPlayerLogin);
     }
 
     private static void handleClientPlayerLogin(ClientPlayerNetworkEvent.LoggingIn event) {
@@ -58,7 +58,7 @@ public class ClientCommandHandler {
     @ApiStatus.Internal
     public static CommandDispatcher<SharedSuggestionProvider> mergeServerCommands(CommandDispatcher<SharedSuggestionProvider> serverCommands, CommandBuildContext buildContext) {
         CommandDispatcher<CommandSourceStack> commandsTemp = new CommandDispatcher<>();
-        MinecraftForge.EVENT_BUS.post(new RegisterClientCommandsEvent(commandsTemp, buildContext));
+        RegisterClientCommandsEvent.BUS.post(new RegisterClientCommandsEvent(commandsTemp, buildContext));
 
         // Copies the client commands into another RootCommandNode so that redirects can't be used with server commands
         commands = new CommandDispatcher<>();

--- a/src/main/java/net/minecraftforge/client/ClientForgeMod.java
+++ b/src/main/java/net/minecraftforge/client/ClientForgeMod.java
@@ -16,7 +16,9 @@ import net.minecraftforge.client.model.ElementsModel;
 import net.minecraftforge.client.model.EmptyModel;
 import net.minecraftforge.client.model.ItemLayerModel;
 import net.minecraftforge.client.model.SeparateTransformsModel;
+import net.minecraftforge.client.model.data.ModelDataManager;
 import net.minecraftforge.client.model.obj.ObjLoader;
+import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -41,5 +43,10 @@ public class ClientForgeMod {
     @SubscribeEvent
     public static void onRegisterNamedRenderTypes(RegisterNamedRenderTypesEvent event) {
         event.register("item_unlit", RenderType.translucent(), ForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
+    }
+
+    @SubscribeEvent
+    public static void onChunkUnload(ChunkEvent.Unload event) {
+        ModelDataManager.onChunkUnload(event);
     }
 }

--- a/src/main/java/net/minecraftforge/client/ClientForgeMod.java
+++ b/src/main/java/net/minecraftforge/client/ClientForgeMod.java
@@ -17,7 +17,7 @@ import net.minecraftforge.client.model.EmptyModel;
 import net.minecraftforge.client.model.ItemLayerModel;
 import net.minecraftforge.client.model.SeparateTransformsModel;
 import net.minecraftforge.client.model.obj.ObjLoader;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD, modid = "forge")

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -19,7 +19,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.datafixers.util.Either;
 import com.mojang.math.Transformation;
 
-import net.minecraft.ChatFormatting;
 import net.minecraft.FileUtil;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
@@ -138,7 +137,6 @@ import net.minecraftforge.client.textures.ForgeTextureMetadata;
 import net.minecraftforge.client.textures.TextureAtlasSpriteLoaderManager;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.common.ForgeMod;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoader;
@@ -232,11 +230,11 @@ public class ForgeHooksClient {
     }
 
     public static boolean onClientPauseChangePre(boolean pause) {
-        return MinecraftForge.EVENT_BUS.post(new ClientPauseChangeEvent.Pre(pause));
+        return ClientPauseChangeEvent.Pre.BUS.post(new ClientPauseChangeEvent.Pre(pause));
     }
 
     public static void onClientPauseChangePost(boolean pause) {
-        MinecraftForge.EVENT_BUS.post(new ClientPauseChangeEvent.Post(pause));
+        ClientPauseChangeEvent.Post.BUS.post(new ClientPauseChangeEvent.Post(pause));
     }
 
     /*
@@ -250,17 +248,17 @@ public class ForgeHooksClient {
         switch (target.getType()) {
             case BLOCK:
                 if (!(target instanceof BlockHitResult blockTarget)) return false;
-                return MinecraftForge.EVENT_BUS.post(new RenderHighlightEvent.Block(context, camera, blockTarget, partialTick, poseStack, bufferSource));
+                return RenderHighlightEvent.Block.BUS.post(new RenderHighlightEvent.Block(context, camera, blockTarget, partialTick, poseStack, bufferSource));
             case ENTITY:
                 if (!(target instanceof EntityHitResult entityTarget)) return false;
-                return MinecraftForge.EVENT_BUS.post(new RenderHighlightEvent.Entity(context, camera, entityTarget, partialTick, poseStack, bufferSource));
+                return RenderHighlightEvent.Entity.BUS.post(new RenderHighlightEvent.Entity(context, camera, entityTarget, partialTick, poseStack, bufferSource));
             default:
                 return false; // NO-OP - This doesn't even get called for anything other than blocks and entities
         }
     }
 
     public static boolean renderSpecificFirstPersonHand(InteractionHand hand, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, float partialTick, float interpPitch, float swingProgress, float equipProgress, ItemStack stack) {
-        return MinecraftForge.EVENT_BUS.post(new RenderHandEvent(hand, poseStack, bufferSource, packedLight, partialTick, interpPitch, swingProgress, equipProgress, stack));
+        return RenderHandEvent.BUS.post(new RenderHandEvent(hand, poseStack, bufferSource, packedLight, partialTick, interpPitch, swingProgress, equipProgress, stack));
     }
 
     public static void onTextureStitchedPost(TextureAtlas map) {
@@ -352,7 +350,7 @@ public class ForgeHooksClient {
 
     @Nullable
     public static SoundInstance playSound(SoundEngine manager, SoundInstance sound) {
-        return MinecraftForge.EVENT_BUS.fire(new PlaySoundEvent(manager, sound)).getSound();
+        return PlaySoundEvent.BUS.fire(new PlaySoundEvent(manager, sound)).getSound();
     }
 
     public static void drawScreen(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
@@ -367,9 +365,9 @@ public class ForgeHooksClient {
     }
 
     private static void drawScreenInternal(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        if (!MinecraftForge.EVENT_BUS.post(new ScreenEvent.Render.Pre(screen, guiGraphics, mouseX, mouseY, partialTick)))
+        if (!ScreenEvent.Render.Pre.BUS.post(new ScreenEvent.Render.Pre(screen, guiGraphics, mouseX, mouseY, partialTick)))
             screen.renderWithTooltip(guiGraphics, mouseX, mouseY, partialTick);
-        MinecraftForge.EVENT_BUS.post(new ScreenEvent.Render.Post(screen, guiGraphics, mouseX, mouseY, partialTick));
+        ScreenEvent.Render.Post.BUS.post(new ScreenEvent.Render.Post(screen, guiGraphics, mouseX, mouseY, partialTick));
     }
 
     public static Vector3f getFogColor(Camera camera, float partialTick, ClientLevel level, int renderDistance, float darkenWorldAmount, float fogRed, float fogGreen, float fogBlue) {
@@ -380,7 +378,7 @@ public class ForgeHooksClient {
             fluidFogColor = IClientFluidTypeExtensions.of(state).modifyFogColor(camera, partialTick, level, renderDistance, darkenWorldAmount, fluidFogColor);
 
         ViewportEvent.ComputeFogColor event = new ViewportEvent.ComputeFogColor(camera, partialTick, fluidFogColor.x(), fluidFogColor.y(), fluidFogColor.z());
-        MinecraftForge.EVENT_BUS.post(event);
+        ViewportEvent.ComputeFogColor.BUS.post(event);
 
         fluidFogColor.set(event.getRed(), event.getGreen(), event.getBlue());
         return fluidFogColor;
@@ -394,7 +392,7 @@ public class ForgeHooksClient {
             ret = IClientFluidTypeExtensions.of(state).modifyFogRender(camera, mode, renderDistance, partialTick, ret);
 
         var event = new ViewportEvent.RenderFog(mode, type, camera, partialTick, ret.start(), ret.end(), ret.shape());
-        if (MinecraftForge.EVENT_BUS.post(event)) {
+        if (ViewportEvent.RenderFog.BUS.post(event)) {
             return new FogParameters(
                 event.getNearPlaneDistance(), event.getFarPlaneDistance(), event.getFogShape(),
                 ret.red(), ret.green(), ret.blue(), ret.alpha()
@@ -456,14 +454,14 @@ public class ForgeHooksClient {
     public static CustomizeGuiOverlayEvent.BossEventProgress onCustomizeBossEventProgress(GuiGraphics guiGraphics, Window window, LerpingBossEvent bossInfo, int x, int y, int increment) {
         var evt = new CustomizeGuiOverlayEvent.BossEventProgress(window, guiGraphics,
                 Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(false), bossInfo, x, y, increment);
-        MinecraftForge.EVENT_BUS.post(evt);
+        CustomizeGuiOverlayEvent.BossEventProgress.BUS.post(evt);
         return evt;
     }
 
     public static void onCustomizeChatEvent(GuiGraphics guiGraphics, ChatComponent chat, Window window, int mouseX, int mouseY, int tickCount) {
         var minecraft = Minecraft.getInstance();
         var evt = new CustomizeGuiOverlayEvent.Chat(window, guiGraphics, minecraft.getDeltaTracker().getRealtimeDeltaTicks(), 0, chat.getHeight() - 40);
-        MinecraftForge.EVENT_BUS.post(evt);
+        CustomizeGuiOverlayEvent.Chat.BUS.post(evt);
         guiGraphics.pose().pushPose();
         // We give the absolute Y position of the chat component in the event and account for the chat component's own offsetting here.
         guiGraphics.pose().translate(evt.getPosX(), (evt.getPosY() - chat.getHeight() + 40) / chat.getScale(), 0.0D);
@@ -474,17 +472,17 @@ public class ForgeHooksClient {
     public static void onCustomizeDebugEvent(GuiGraphics guiGraphics, Window window, float partialTick, List<String> text, boolean isLeft) {
         var evt = new CustomizeGuiOverlayEvent.DebugText(window, guiGraphics, partialTick, text,
                 isLeft ? CustomizeGuiOverlayEvent.DebugText.Side.Left : CustomizeGuiOverlayEvent.DebugText.Side.Right);
-        MinecraftForge.EVENT_BUS.post(evt);
+        CustomizeGuiOverlayEvent.DebugText.BUS.post(evt);
     }
 
     public static void onClientChangeGameType(PlayerInfo info, GameType currentGameMode, GameType newGameMode) {
         if (currentGameMode != newGameMode) {
-            MinecraftForge.EVENT_BUS.post(new ClientPlayerChangeGameTypeEvent(info, currentGameMode, newGameMode));
+            ClientPlayerChangeGameTypeEvent.BUS.post(new ClientPlayerChangeGameTypeEvent(info, currentGameMode, newGameMode));
         }
     }
 
     public static void onMovementInputUpdate(Player player, ClientInput movementInput) {
-        MinecraftForge.EVENT_BUS.post(new MovementInputUpdateEvent(player, movementInput));
+        MovementInputUpdateEvent.BUS.post(new MovementInputUpdateEvent(player, movementInput));
     }
 
     public static boolean onScreenKeyPressed(Screen screen, int keyCode, int scanCode, int modifiers) {
@@ -506,7 +504,7 @@ public class ForgeHooksClient {
     }
 
     public static void onKeyInput(int key, int scanCode, int action, int modifiers) {
-        MinecraftForge.EVENT_BUS.post(new InputEvent.Key(key, scanCode, action, modifiers));
+        InputEvent.Key.BUS.post(new InputEvent.Key(key, scanCode, action, modifiers));
     }
 
     public static boolean isNameplateInRenderDistance(Entity entity, double squareDistance) {
@@ -677,26 +675,26 @@ public class ForgeHooksClient {
     @Nullable
     public static Component onClientChat(ChatType.Bound boundChatType, Component message, UUID sender) {
         ClientChatReceivedEvent event = new ClientChatReceivedEvent(boundChatType, message, sender);
-        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
+        return ClientChatReceivedEvent.BUS.post(event) ? null : event.getMessage();
     }
 
     @Nullable
     public static Component onClientPlayerChat(ChatType.Bound boundChatType, Component message, PlayerChatMessage playerChatMessage, UUID sender) {
         ClientChatReceivedEvent.Player event = new ClientChatReceivedEvent.Player(boundChatType, message, playerChatMessage, sender);
-        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
+        return ClientChatReceivedEvent.Player.BUS.post(event) ? null : event.getMessage();
     }
 
     @Nullable
     public static Component onClientSystemMessage(Component message, boolean overlay) {
         var event = new SystemMessageReceivedEvent(message, overlay);
-        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
+        return SystemMessageReceivedEvent.BUS.post(event) ? null : event.getMessage();
 
     }
 
     @NotNull
     public static String onClientSendMessage(String message) {
         ClientChatEvent event = new ClientChatEvent(message);
-        return MinecraftForge.EVENT_BUS.post(event) ? "" : event.getMessage();
+        return ClientChatEvent.BUS.post(event) ? "" : event.getMessage();
     }
 
     public static final Supplier<ShaderProgram> SHADER_UNLIT_TRANSLUCENT = Suppliers.memoize(() ->
@@ -710,8 +708,7 @@ public class ForgeHooksClient {
 
     public static RenderTooltipEvent.Pre onRenderTooltipPre(@NotNull ItemStack stack, GuiGraphics graphics, int x, int y, int screenWidth, int screenHeight, @NotNull List<ClientTooltipComponent> components, @NotNull Font fallbackFont, @NotNull ClientTooltipPositioner positioner) {
         var preEvent = new RenderTooltipEvent.Pre(stack, graphics, x, y, screenWidth, screenHeight, getTooltipFont(stack, fallbackFont), components, positioner);
-        MinecraftForge.EVENT_BUS.post(preEvent);
-        return preEvent;
+        return RenderTooltipEvent.Pre.BUS.post(preEvent) ? null : preEvent;
     }
 
     public static List<ClientTooltipComponent> gatherTooltipComponents(ItemStack stack, List<? extends FormattedText> textElements, int mouseX, int screenWidth, int screenHeight, Font fallbackFont) {
@@ -730,7 +727,7 @@ public class ForgeHooksClient {
         Font font = getTooltipFont(stack, fallbackFont);
 
         var event = new RenderTooltipEvent.GatherComponents(stack, screenWidth, screenHeight, elements, -1);
-        if (MinecraftForge.EVENT_BUS.post(event)) return List.of();
+        if (RenderTooltipEvent.GatherComponents.BUS.post(event)) return List.of();
 
         // text wrapping
         int tooltipTextWidth = event.getTooltipElements().stream()
@@ -824,7 +821,7 @@ public class ForgeHooksClient {
     }
 
     public static boolean renderBlockOverlay(Player player, PoseStack mat, RenderBlockScreenEffectEvent.OverlayType type, BlockState block, BlockPos pos) {
-        return MinecraftForge.EVENT_BUS.post(new RenderBlockScreenEffectEvent(player, mat, type, block, pos));
+        return RenderBlockScreenEffectEvent.BUS.post(new RenderBlockScreenEffectEvent(player, mat, type, block, pos));
     }
 
     public static int getMaxMipmapLevel(int width, int height) {

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -7,8 +7,9 @@ package net.minecraftforge.client.event;
 
 import com.google.common.base.Strings;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -21,9 +22,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  **/
-@Cancelable
-public class ClientChatEvent extends Event
-{
+public class ClientChatEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ClientChatEvent> BUS = CancellableEventBus.create(ClientChatEvent.class);
+
     private String message;
     private final String originalMessage;
 

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.PlayerChatMessage;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import java.util.UUID;
@@ -28,8 +29,9 @@ import java.util.UUID;
  *
  * @see ChatType
  */
-@Cancelable
-public class ClientChatReceivedEvent extends Event {
+public class ClientChatReceivedEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ClientChatReceivedEvent> BUS = CancellableEventBus.create(ClientChatReceivedEvent.class);
+
     private Component message;
     private final ChatType.Bound boundChatType;
     private final UUID sender;
@@ -94,7 +96,9 @@ public class ClientChatReceivedEvent extends Event {
      *
      * @see ChatType
      */
-    public static class Player extends ClientChatReceivedEvent {
+    public static class Player extends ClientChatReceivedEvent implements Cancellable {
+        public static final CancellableEventBus<Player> BUS = CancellableEventBus.create(Player.class);
+
         private final PlayerChatMessage playerChatMessage;
 
         @ApiStatus.Internal
@@ -119,7 +123,9 @@ public class ClientChatReceivedEvent extends Event {
      * So moved to it's own event. {@link SystemMessageReceivedEvent}
      */
     @Deprecated(forRemoval = true, since = "1.21.1")
-    public static class System extends ClientChatReceivedEvent {
+    public static class System extends ClientChatReceivedEvent implements Cancellable {
+        public static final CancellableEventBus<System> BUS = CancellableEventBus.create(System.class);
+
         private final boolean overlay;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/ClientPauseChangeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPauseChangeEvent.java
@@ -6,10 +6,12 @@
 package net.minecraftforge.client.event;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 import net.minecraft.client.Minecraft;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -21,7 +23,9 @@ import net.minecraftforge.fml.LogicalSide;
  * @see ClientPauseChangeEvent.Pre
  * @see ClientPauseChangeEvent.Post
  */
-public abstract class ClientPauseChangeEvent extends Event {
+public abstract class ClientPauseChangeEvent extends MutableEvent {
+    public static final EventBus<ClientPauseChangeEvent> BUS = EventBus.create(ClientPauseChangeEvent.class);
+
     private final boolean pause;
 
     public ClientPauseChangeEvent(boolean pause) {
@@ -37,8 +41,8 @@ public abstract class ClientPauseChangeEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Pre extends ClientPauseChangeEvent {
+    public static class Pre extends ClientPauseChangeEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
 
         public Pre(boolean pause) {
             super(pause);
@@ -54,6 +58,7 @@ public abstract class ClientPauseChangeEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Post extends ClientPauseChangeEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
 
         public Post(boolean pause) {
             super(pause);

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameTypeEvent.java
@@ -8,8 +8,8 @@ package net.minecraftforge.client.event;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -21,8 +21,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class ClientPlayerChangeGameTypeEvent extends Event
-{
+public class ClientPlayerChangeGameTypeEvent extends MutableEvent {
+    public static final EventBus<ClientPlayerChangeGameTypeEvent> BUS = EventBus.create(ClientPlayerChangeGameTypeEvent.class);
+
     private final PlayerInfo info;
     private final GameType currentGameType;
     private final GameType newGameType;

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
@@ -9,8 +9,8 @@ import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.Connection;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -26,7 +26,9 @@ import org.jetbrains.annotations.Nullable;
  * @see LoggingOut
  * @see Clone
  **/
-public abstract class ClientPlayerNetworkEvent extends Event {
+public abstract class ClientPlayerNetworkEvent extends MutableEvent {
+    public static final EventBus<ClientPlayerNetworkEvent> BUS = EventBus.create(ClientPlayerNetworkEvent.class);
+
     private final MultiPlayerGameMode multiPlayerGameMode;
     private final LocalPlayer player;
     private final Connection connection;
@@ -68,6 +70,8 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class LoggingIn extends ClientPlayerNetworkEvent {
+        public static final EventBus<LoggingIn> BUS = EventBus.create(LoggingIn.class);
+
         @ApiStatus.Internal
         public LoggingIn(final MultiPlayerGameMode controller, final LocalPlayer player, final Connection networkManager) {
             super(controller, player, networkManager);
@@ -85,6 +89,8 @@ public abstract class ClientPlayerNetworkEvent extends Event {
     @SuppressWarnings("NullableProblems")
     // Shush IntelliJ, we override non-nullables as nullables in this specific event; see later comment
     public static class LoggingOut extends ClientPlayerNetworkEvent {
+        public static final EventBus<LoggingOut> BUS = EventBus.create(LoggingOut.class);
+
         @ApiStatus.Internal
         public LoggingOut(@Nullable final MultiPlayerGameMode controller, @Nullable final LocalPlayer player, @Nullable final Connection networkManager) {
             //noinspection ConstantConditions we know these are nullable, but we don't want to annotate the super as nullable since this is the only event with nullables
@@ -134,6 +140,8 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Clone extends ClientPlayerNetworkEvent {
+        public static final EventBus<Clone> BUS = EventBus.create(Clone.class);
+
         private final LocalPlayer oldPlayer;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ComputeFovModifierEvent.java
@@ -5,12 +5,11 @@
 
 package net.minecraftforge.client.event;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -24,7 +23,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see ViewportEvent.ComputeFov
  */
-public class ComputeFovModifierEvent extends Event {
+public class ComputeFovModifierEvent extends MutableEvent {
+    public static final EventBus<ComputeFovModifierEvent> BUS = EventBus.create(ComputeFovModifierEvent.class);
+
     private final Player player;
     private final float fovModifier;
     private final float scale;

--- a/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ContainerScreenEvent.java
@@ -8,8 +8,8 @@ package net.minecraftforge.client.event;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -23,7 +23,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Render.Foreground
  * @see Render.Background
  */
-public abstract class ContainerScreenEvent extends Event {
+public abstract class ContainerScreenEvent extends MutableEvent {
+    public static final EventBus<ContainerScreenEvent> BUS = EventBus.create(ContainerScreenEvent.class);
+
     private final AbstractContainerScreen<?> containerScreen;
 
     @ApiStatus.Internal
@@ -49,6 +51,8 @@ public abstract class ContainerScreenEvent extends Event {
      * @see Background
      */
     public static abstract class Render extends ContainerScreenEvent {
+        public static final EventBus<Render> BUS = EventBus.create(Render.class);
+
         private final GuiGraphics guiGraphics;
         private final int mouseX;
         private final int mouseY;
@@ -95,6 +99,8 @@ public abstract class ContainerScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Foreground extends Render {
+            public static final EventBus<Foreground> BUS = EventBus.create(Foreground.class);
+
             @ApiStatus.Internal
             public Foreground(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
                 super(guiContainer, guiGraphics, mouseX, mouseY);
@@ -111,6 +117,8 @@ public abstract class ContainerScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Background extends Render {
+            public static final EventBus<Background> BUS = EventBus.create(Background.class);
+
             @ApiStatus.Internal
             public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {
                 super(guiContainer, guiGraphics, mouseX, mouseY);

--- a/src/main/java/net/minecraftforge/client/event/CreateSpecialBlockRendererEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CreateSpecialBlockRendererEvent.java
@@ -9,9 +9,12 @@ import java.util.Map;
 
 import net.minecraft.client.renderer.special.SpecialModelRenderer;
 import net.minecraft.world.level.block.Block;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
-public class CreateSpecialBlockRendererEvent extends Event {
+public class CreateSpecialBlockRendererEvent extends MutableEvent {
+    public static final EventBus<CreateSpecialBlockRendererEvent> BUS = EventBus.create(CreateSpecialBlockRendererEvent.class);
+
     private final Map<Block, SpecialModelRenderer.Unbaked> map;
 
     public CreateSpecialBlockRendererEvent(Map<Block, SpecialModelRenderer.Unbaked> map) {

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -9,8 +9,10 @@ import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -23,7 +25,9 @@ import java.util.List;
  * @see DebugText
  * @see Chat
  */
-public abstract class CustomizeGuiOverlayEvent extends Event {
+public abstract class CustomizeGuiOverlayEvent extends MutableEvent {
+    public static final EventBus<CustomizeGuiOverlayEvent> BUS = EventBus.create(CustomizeGuiOverlayEvent.class);
+
     private final Window window;
     private final GuiGraphics guiGraphics;
     private final float partialTick;
@@ -56,8 +60,9 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class BossEventProgress extends CustomizeGuiOverlayEvent {
+    public static class BossEventProgress extends CustomizeGuiOverlayEvent implements Cancellable {
+        public static final CancellableEventBus<BossEventProgress> BUS = CancellableEventBus.create(BossEventProgress.class);
+
         private final LerpingBossEvent bossEvent;
         private final int x;
         private final int y;
@@ -120,6 +125,8 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class DebugText extends CustomizeGuiOverlayEvent {
+        public static final EventBus<DebugText> BUS = EventBus.create(DebugText.class);
+
         private final List<String> text;
 
         private final Side side;
@@ -160,6 +167,8 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Chat extends CustomizeGuiOverlayEvent {
+        public static final EventBus<Chat> BUS = EventBus.create(Chat.class);
+
         private int posX;
         private int posY;
 

--- a/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/CustomizeGuiOverlayEvent.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
@@ -60,7 +61,7 @@ public abstract class CustomizeGuiOverlayEvent extends MutableEvent {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class BossEventProgress extends CustomizeGuiOverlayEvent implements Cancellable {
+    public static class BossEventProgress extends CustomizeGuiOverlayEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<BossEventProgress> BUS = CancellableEventBus.create(BossEventProgress.class);
 
         private final LerpingBossEvent bossEvent;

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -29,6 +29,8 @@ import net.minecraft.world.level.block.SkullBlock.Type;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -53,8 +55,6 @@ import java.util.function.Supplier;
  * @see EntityRenderersEvent.AddLayers
  */
 public abstract class EntityRenderersEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
-
     @ApiStatus.Internal
     protected EntityRenderersEvent() {}
 
@@ -67,7 +67,9 @@ public abstract class EntityRenderersEvent extends MutableEvent implements IModB
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterLayerDefinitions extends EntityRenderersEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<RegisterLayerDefinitions> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, RegisterLayerDefinitions.class);
+        }
 
         @ApiStatus.Internal
         public RegisterLayerDefinitions() {}
@@ -97,7 +99,9 @@ public abstract class EntityRenderersEvent extends MutableEvent implements IModB
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterRenderers extends EntityRenderersEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<RegisterRenderers> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, RegisterRenderers.class);
+        }
 
         @ApiStatus.Internal
         public RegisterRenderers() {}
@@ -133,7 +137,9 @@ public abstract class EntityRenderersEvent extends MutableEvent implements IModB
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class AddLayers extends EntityRenderersEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<AddLayers> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, AddLayers.class);
+        }
 
         private final Map<EntityType<?>, EntityRenderer<?, ?>> renderers;
         private final Map<PlayerSkin.Model, EntityRenderer<? extends Player, ?>> skinMap;
@@ -209,7 +215,9 @@ public abstract class EntityRenderersEvent extends MutableEvent implements IModB
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class CreateSkullModels extends EntityRenderersEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<CreateSkullModels> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, CreateSkullModels.class);
+        }
 
         private final ImmutableMap.Builder<Type, Function<EntityModelSet, SkullModelBase>> builder;
 

--- a/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityRenderersEvent.java
@@ -29,8 +29,7 @@ import net.minecraft.world.level.block.SkullBlock.Type;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.client.ForgeHooksClient;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -53,7 +52,9 @@ import java.util.function.Supplier;
  * @see EntityRenderersEvent.RegisterRenderers
  * @see EntityRenderersEvent.AddLayers
  */
-public abstract class EntityRenderersEvent extends Event implements IModBusEvent {
+public abstract class EntityRenderersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     @ApiStatus.Internal
     protected EntityRenderersEvent() {}
 
@@ -66,6 +67,8 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterLayerDefinitions extends EntityRenderersEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         @ApiStatus.Internal
         public RegisterLayerDefinitions() {}
 
@@ -94,6 +97,8 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterRenderers extends EntityRenderersEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         @ApiStatus.Internal
         public RegisterRenderers() {}
 
@@ -128,6 +133,8 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class AddLayers extends EntityRenderersEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         private final Map<EntityType<?>, EntityRenderer<?, ?>> renderers;
         private final Map<PlayerSkin.Model, EntityRenderer<? extends Player, ?>> skinMap;
         private final EntityRendererProvider.Context context;
@@ -202,6 +209,8 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class CreateSkullModels extends EntityRenderersEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         private final ImmutableMap.Builder<Type, Function<EntityModelSet, SkullModelBase>> builder;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
+++ b/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
@@ -213,12 +213,14 @@ public final class ForgeEventFactoryClient {
 
     public static <T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> boolean onRenderLivingPre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
         // Todo: [Forge][EventFactoryClient] Fix posting this
-        return RenderLivingEvent.Pre.BUS.post(new RenderLivingEvent.Pre<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
+        return false;
+//        return post(new RenderLivingEvent.Pre<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static <T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> boolean onRenderLivingPost(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
         // Todo: [Forge][EventFactoryClient] Fix posting this
-        return RenderLivingEvent.Post.BUS.post(new RenderLivingEvent.Post<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
+        return false;
+//        return post(new RenderLivingEvent.Post<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static boolean onRenderPlayerPre(PlayerRenderState player, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {

--- a/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
+++ b/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
@@ -10,9 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
@@ -67,7 +66,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SkullBlock.Type;
 import net.minecraftforge.client.event.sound.PlaySoundSourceEvent;
 import net.minecraftforge.client.event.sound.PlayStreamingSourceEvent;
-import net.minecraftforge.eventbus.api.Event;
 
 @ApiStatus.Internal
 public final class ForgeEventFactoryClient {
@@ -76,25 +74,9 @@ public final class ForgeEventFactoryClient {
     private ForgeEventFactoryClient() {}
 
     /**
-     * Post an event to the {@link MinecraftForge#EVENT_BUS}
-     * @return true if the event is {@link Cancelable} and has been canceled
-     */
-    private static boolean post(Event e) {
-        return MinecraftForge.EVENT_BUS.post(e);
-    }
-
-    /**
-     * Post an event to the {@link MinecraftForge#EVENT_BUS}, then return the event object
-     * @return the event object passed in and possibly modified by listeners
-     */
-    private static <E extends Event> E fire(E e) {
-        return MinecraftForge.EVENT_BUS.fire(e);
-    }
-
-    /**
      * Post an event to the {@link ModLoader#get()} event bus
      */
-    private static <T extends Event & IModBusEvent> T fireModBus(T e) {
+    private static <T extends IModBusEvent> T fireModBus(T e) {
         ML.postEvent(e);
         return e;
     }
@@ -105,192 +87,198 @@ public final class ForgeEventFactoryClient {
     }
 
     public static boolean onScreenMouseReleased(Screen screen, double mouseX, double mouseY, int button) {
-        if (post(new ScreenEvent.MouseButtonReleased.Pre(screen, mouseX, mouseY, button)))
+        if (ScreenEvent.MouseButtonReleased.Pre.BUS.post(new ScreenEvent.MouseButtonReleased.Pre(screen, mouseX, mouseY, button)))
             return true;
 
         var ret = screen.mouseReleased(mouseX, mouseY, button);
-        var result = fire(new ScreenEvent.MouseButtonReleased.Post(screen, mouseX, mouseY, button, ret)).getResult();
-        return result == Event.Result.DEFAULT ? ret : result == Event.Result.ALLOW;
+        var result = ScreenEvent.MouseButtonReleased.Post.BUS.fire(new ScreenEvent.MouseButtonReleased.Post(screen, mouseX, mouseY, button, ret)).getResult();
+        return result == Result.DEFAULT ? ret : result == Result.ALLOW;
     }
 
     public static boolean onScreenMouseClicked(Screen screen, double mouseX, double mouseY, int button) {
-        var ret = post(new ScreenEvent.MouseButtonPressed.Pre(screen, mouseX, mouseY, button));
+        var ret = ScreenEvent.MouseButtonPressed.Pre.BUS.post(new ScreenEvent.MouseButtonPressed.Pre(screen, mouseX, mouseY, button));
         if (!ret)
             ret = screen.mouseClicked(mouseX, mouseY, button);
 
-        var result = fire(new ScreenEvent.MouseButtonPressed.Post(screen, mouseX, mouseY, button, ret)).getResult();
-        return result == Event.Result.DEFAULT ? ret : result == Event.Result.ALLOW;
+        var result = ScreenEvent.MouseButtonPressed.Post.BUS.fire(new ScreenEvent.MouseButtonPressed.Post(screen, mouseX, mouseY, button, ret)).getResult();
+        return result == Result.DEFAULT ? ret : result == Result.ALLOW;
     }
 
     public static boolean onMouseButtonPre(int button, int action, int mods) {
-        return post(new InputEvent.MouseButton.Pre(button, action, mods));
+        return InputEvent.MouseButton.Pre.BUS.post(new InputEvent.MouseButton.Pre(button, action, mods));
     }
 
     public static void onMouseButtonPost(int button, int action, int mods) {
-        post(new InputEvent.MouseButton.Post(button, action, mods));
+        InputEvent.MouseButton.Post.BUS.post(new InputEvent.MouseButton.Post(button, action, mods));
     }
 
     public static boolean onScreenMouseScrollPre(Screen guiScreen, double mouseX, double mouseY, double deltaX, double deltaY) {
-        return post(new ScreenEvent.MouseScrolled.Pre(guiScreen, mouseX, mouseY, deltaX, deltaY));
+        return ScreenEvent.MouseScrolled.Pre.BUS.post(new ScreenEvent.MouseScrolled.Pre(guiScreen, mouseX, mouseY, deltaX, deltaY));
     }
 
     public static void onScreenMouseScrollPost(Screen guiScreen, double mouseX, double mouseY, double deltaX, double deltaY) {
-        post(new ScreenEvent.MouseScrolled.Post(guiScreen, mouseX, mouseY, deltaX, deltaY));
+        ScreenEvent.MouseScrolled.Post.BUS.post(new ScreenEvent.MouseScrolled.Post(guiScreen, mouseX, mouseY, deltaX, deltaY));
     }
 
     public static boolean onMouseScroll(MouseHandler mouseHelper, double deltaX, double deltaY) {
-        return post(new InputEvent.MouseScrollingEvent(deltaX, deltaY, mouseHelper.isLeftPressed(), mouseHelper.isMiddlePressed(), mouseHelper.isRightPressed(), mouseHelper.xpos(), mouseHelper.ypos()));
+        return InputEvent.MouseScrollingEvent.BUS.post(new InputEvent.MouseScrollingEvent(deltaX, deltaY, mouseHelper.isLeftPressed(), mouseHelper.isMiddlePressed(), mouseHelper.isRightPressed(), mouseHelper.xpos(), mouseHelper.ypos()));
     }
 
     public static boolean onScreenMouseDragPre(Screen guiScreen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
-        return post(new ScreenEvent.MouseDragged.Pre(guiScreen, mouseX, mouseY, mouseButton, dragX, dragY));
+        return ScreenEvent.MouseDragged.Pre.BUS.post(new ScreenEvent.MouseDragged.Pre(guiScreen, mouseX, mouseY, mouseButton, dragX, dragY));
     }
 
     public static boolean onScreenMouseDragPost(Screen guiScreen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
-        return post(new ScreenEvent.MouseDragged.Post(guiScreen, mouseX, mouseY, mouseButton, dragX, dragY));
+        return ScreenEvent.MouseDragged.Post.BUS.post(new ScreenEvent.MouseDragged.Post(guiScreen, mouseX, mouseY, mouseButton, dragX, dragY));
     }
 
     public static @Nullable Screen onScreenOpening(Screen old, Screen screen) {
          var event = new ScreenEvent.Opening(old, screen);
-         if (post(event))
+         if (ScreenEvent.Opening.BUS.post(event))
              return null;
          return event.getNewScreen();
     }
 
     public static void onScreenClose(Screen screen) {
-        post(new ScreenEvent.Closing(screen));
+        ScreenEvent.Closing.BUS.post(new ScreenEvent.Closing(screen));
     }
 
     public static void onPlaySoundSource(SoundEngine engine, SoundInstance sound, Channel channel) {
-        post(new PlaySoundSourceEvent(engine, sound, channel));
+        PlaySoundSourceEvent.BUS.post(new PlaySoundSourceEvent(engine, sound, channel));
     }
 
     public static void onPlayStreamingSource(SoundEngine engine, SoundInstance sound, Channel channel) {
-        post(new PlayStreamingSourceEvent(engine, sound, channel));
+        PlayStreamingSourceEvent.BUS.post(new PlayStreamingSourceEvent(engine, sound, channel));
     }
 
     public static ScreenshotEvent onScreenshot(NativeImage image, File screenshotFile) {
-        return fire(new ScreenshotEvent(image, screenshotFile));
+        return ScreenshotEvent.BUS.fire(new ScreenshotEvent(image, screenshotFile));
     }
 
     public static boolean onScreenKeyPressedPre(Screen screen, int keyCode, int scanCode, int modifiers) {
-        return post(new ScreenEvent.KeyPressed.Pre(screen, keyCode, scanCode, modifiers));
+        return ScreenEvent.KeyPressed.Pre.BUS.post(new ScreenEvent.KeyPressed.Pre(screen, keyCode, scanCode, modifiers));
     }
 
     public static boolean onScreenKeyPressedPost(Screen screen, int keyCode, int scanCode, int modifiers) {
-        return post(new ScreenEvent.KeyPressed.Post(screen, keyCode, scanCode, modifiers));
+        return ScreenEvent.KeyPressed.Post.BUS.post(new ScreenEvent.KeyPressed.Post(screen, keyCode, scanCode, modifiers));
     }
 
     public static boolean onScreenKeyReleasedPre(Screen screen, int keyCode, int scanCode, int modifiers) {
-        return post(new ScreenEvent.KeyReleased.Pre(screen, keyCode, scanCode, modifiers));
+        return ScreenEvent.KeyReleased.Pre.BUS.post(new ScreenEvent.KeyReleased.Pre(screen, keyCode, scanCode, modifiers));
     }
 
     public static boolean onScreenKeyReleasedPost(Screen screen, int keyCode, int scanCode, int modifiers) {
-        return post(new ScreenEvent.KeyReleased.Post(screen, keyCode, scanCode, modifiers));
+        return ScreenEvent.KeyReleased.Post.BUS.post(new ScreenEvent.KeyReleased.Post(screen, keyCode, scanCode, modifiers));
     }
 
     public static boolean onScreenCharTypedPre(Screen screen, char codePoint, int modifiers) {
-        return post(new ScreenEvent.CharacterTyped.Pre(screen, codePoint, modifiers));
+        return ScreenEvent.CharacterTyped.Pre.BUS.post(new ScreenEvent.CharacterTyped.Pre(screen, codePoint, modifiers));
     }
 
     public static boolean onScreenCharTypedPost(Screen screen, char codePoint, int modifiers) {
-        return post(new ScreenEvent.CharacterTyped.Post(screen, codePoint, modifiers));
+        return ScreenEvent.CharacterTyped.Post.BUS.post(new ScreenEvent.CharacterTyped.Post(screen, codePoint, modifiers));
     }
 
     public static InputEvent.InteractionKeyMappingTriggered onClickInput(int button, KeyMapping keyBinding, InteractionHand hand) {
-        return fire(new InputEvent.InteractionKeyMappingTriggered(button, keyBinding, hand));
+        return InputEvent.InteractionKeyMappingTriggered.BUS.fire(new InputEvent.InteractionKeyMappingTriggered(button, keyBinding, hand));
     }
 
     public static void onContainerRenderBackground(AbstractContainerScreen<?> screen, GuiGraphics graphics, int mouseX, int mouseY) {
-        post(new ContainerScreenEvent.Render.Background(screen, graphics, mouseX, mouseY));
+        ContainerScreenEvent.Render.Background.BUS.post(new ContainerScreenEvent.Render.Background(screen, graphics, mouseX, mouseY));
     }
 
     public static void onContainerRenderForeground(AbstractContainerScreen<?> screen, GuiGraphics graphics, int mouseX, int mouseY) {
-        post(new ContainerScreenEvent.Render.Foreground(screen, graphics, mouseX, mouseY));
+        ContainerScreenEvent.Render.Foreground.BUS.post(new ContainerScreenEvent.Render.Foreground(screen, graphics, mouseX, mouseY));
     }
 
     public static void firePlayerLogin(MultiPlayerGameMode pc, LocalPlayer player, Connection networkManager) {
-        post(new ClientPlayerNetworkEvent.LoggingIn(pc, player, networkManager));
+        ClientPlayerNetworkEvent.LoggingIn.BUS.post(new ClientPlayerNetworkEvent.LoggingIn(pc, player, networkManager));
     }
 
     public static void firePlayerLogout(@Nullable MultiPlayerGameMode pc, @Nullable LocalPlayer player) {
-        post(new ClientPlayerNetworkEvent.LoggingOut(pc, player, player != null ? player.connection != null ? player.connection.getConnection() : null : null));
+        ClientPlayerNetworkEvent.LoggingOut.BUS.post(new ClientPlayerNetworkEvent.LoggingOut(pc, player, player != null ? player.connection != null ? player.connection.getConnection() : null : null));
     }
 
     public static void firePlayerRespawn(MultiPlayerGameMode pc, LocalPlayer oldPlayer, LocalPlayer newPlayer, Connection networkManager) {
-        post(new ClientPlayerNetworkEvent.Clone(pc, oldPlayer, newPlayer, networkManager));
+        ClientPlayerNetworkEvent.Clone.BUS.post(new ClientPlayerNetworkEvent.Clone(pc, oldPlayer, newPlayer, networkManager));
     }
 
     public static ViewportEvent.ComputeFov fireComputeFov(GameRenderer renderer, Camera camera, double partialTick, float fov, boolean usedConfiguredFov) {
-        return fire(new ViewportEvent.ComputeFov(renderer, camera, partialTick, fov, usedConfiguredFov));
+        return ViewportEvent.ComputeFov.BUS.fire(new ViewportEvent.ComputeFov(renderer, camera, partialTick, fov, usedConfiguredFov));
     }
 
     public static ViewportEvent.ComputeCameraAngles fireComputeCameraAngles(GameRenderer renderer, Camera camera, float partial) {
-        return fire(new ViewportEvent.ComputeCameraAngles(renderer, camera, partial, camera.getYRot(), camera.getXRot(), 0));
+        return ViewportEvent.ComputeCameraAngles.BUS.fire(new ViewportEvent.ComputeCameraAngles(renderer, camera, partial, camera.getYRot(), camera.getXRot(), 0));
     }
 
     public static <T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> boolean onRenderLivingPre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        return post(new RenderLivingEvent.Pre<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
+        // Todo: [Forge][EventFactoryClient] Fix posting this
+        return false;
+//        return post(new RenderLivingEvent.Pre<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static <T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> boolean onRenderLivingPost(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        return post(new RenderLivingEvent.Post<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
+        // Todo: [Forge][EventFactoryClient] Fix posting this
+        return false;
+//        return post(new RenderLivingEvent.Post<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static boolean onRenderPlayerPre(PlayerRenderState player, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        return post(new RenderPlayerEvent.Pre(player, renderer, poseStack, multiBufferSource, packedLight));
+        return RenderPlayerEvent.Pre.BUS.post(new RenderPlayerEvent.Pre(player, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static boolean onRenderPlayerPost(PlayerRenderState player, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        return post(new RenderPlayerEvent.Post(player, renderer, poseStack, multiBufferSource, packedLight));
+        return RenderPlayerEvent.Post.BUS.post(new RenderPlayerEvent.Post(player, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static boolean onRenderArm(PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight, HumanoidArm arm) {
-        return post(new RenderArmEvent(poseStack, multiBufferSource, packedLight, arm));
+        return RenderArmEvent.BUS.post(new RenderArmEvent(poseStack, multiBufferSource, packedLight, arm));
     }
 
     public static boolean onRenderItemInFrame(ItemFrameRenderState state, ItemFrameRenderer<?> renderItemFrame, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        return post(new RenderItemInFrameEvent(state, renderItemFrame, poseStack, multiBufferSource, packedLight));
+        return RenderItemInFrameEvent.BUS.post(new RenderItemInFrameEvent(state, renderItemFrame, poseStack, multiBufferSource, packedLight));
     }
 
     public static RenderNameTagEvent fireRenderNameTagEvent(EntityRenderState state, Component content, EntityRenderer<?, ?> entityRenderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
-        return fire(new RenderNameTagEvent(state, content, entityRenderer, poseStack, multiBufferSource, packedLight));
+        return RenderNameTagEvent.BUS.fire(new RenderNameTagEvent(state, content, entityRenderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static void onRenderScreenBackground(Screen screen, GuiGraphics guiGraphics) {
-        fire(new ScreenEvent.BackgroundRendered(screen, guiGraphics));
+        ScreenEvent.BackgroundRendered.BUS.fire(new ScreenEvent.BackgroundRendered(screen, guiGraphics));
     }
 
     public static void onRenderTickStart(DeltaTracker timer) {
-        post(new TickEvent.RenderTickEvent.Pre(timer));
+        TickEvent.RenderTickEvent.Pre.BUS.post(new TickEvent.RenderTickEvent.Pre(timer));
     }
 
     public static void onRenderTickEnd(DeltaTracker timer) {
-        post(new TickEvent.RenderTickEvent.Post(timer));
+        TickEvent.RenderTickEvent.Post.BUS.post(new TickEvent.RenderTickEvent.Post(timer));
     }
 
     public static RenderTooltipEvent.Background onRenderTooltipBackground(@NotNull ItemStack stack, GuiGraphics graphics, int x, int y, @NotNull Font font, @NotNull List<ClientTooltipComponent> components, @Nullable ResourceLocation backgroundPrefix) {
-        return fire(new RenderTooltipEvent.Background(stack, graphics, x, y, font, components, backgroundPrefix));
+        return RenderTooltipEvent.Background.BUS.fire(new RenderTooltipEvent.Background(stack, graphics, x, y, font, components, backgroundPrefix));
     }
 
     public static boolean onToastAdd(Toast toast) {
-        return post(new ToastAddEvent(toast));
+        return ToastAddEvent.BUS.post(new ToastAddEvent(toast));
     }
 
+    @Nullable
     public static ScreenEvent.RenderInventoryMobEffects onScreenEffectSize(Screen screen, int availableSpace, boolean compact, int horizontalOffset) {
-        return fire(new ScreenEvent.RenderInventoryMobEffects(screen, availableSpace, compact, horizontalOffset));
+        var event = new ScreenEvent.RenderInventoryMobEffects(screen, availableSpace, compact, horizontalOffset);
+        return ScreenEvent.RenderInventoryMobEffects.BUS.post(event) ? null : event;
     }
 
     public static void onRecipesUpdated(ClientRecipeBook book) {
-        post(new RecipesUpdatedEvent(book));
+        RecipesUpdatedEvent.BUS.post(new RecipesUpdatedEvent(book));
     }
 
     public static ComputeFovModifierEvent fireFovModifierEvent(Player entity, float modifier, float scale) {
-        return fire(new ComputeFovModifierEvent(entity, modifier, scale));
+        return ComputeFovModifierEvent.BUS.fire(new ComputeFovModifierEvent(entity, modifier, scale));
     }
 
     public static void onCreateSpecialBlockRenderers(Map<Block, SpecialModelRenderer.Unbaked> map) {
-        post(new CreateSpecialBlockRendererEvent(map));
+        CreateSpecialBlockRendererEvent.BUS.post(new CreateSpecialBlockRendererEvent(map));
     }
 
     public static Map<Type, Function<EntityModelSet, SkullModelBase>> onCreateSkullModels() {

--- a/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
+++ b/src/main/java/net/minecraftforge/client/event/ForgeEventFactoryClient.java
@@ -213,14 +213,12 @@ public final class ForgeEventFactoryClient {
 
     public static <T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> boolean onRenderLivingPre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
         // Todo: [Forge][EventFactoryClient] Fix posting this
-        return false;
-//        return post(new RenderLivingEvent.Pre<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
+        return RenderLivingEvent.Pre.BUS.post(new RenderLivingEvent.Pre<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static <T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> boolean onRenderLivingPost(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
         // Todo: [Forge][EventFactoryClient] Fix posting this
-        return false;
-//        return post(new RenderLivingEvent.Post<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
+        return RenderLivingEvent.Post.BUS.post(new RenderLivingEvent.Post<T, S, M>(state, renderer, poseStack, multiBufferSource, packedLight));
     }
 
     public static boolean onRenderPlayerPre(PlayerRenderState player, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
@@ -143,7 +144,7 @@ public abstract class InputEvent extends MutableEvent {
      *
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
      */
-    public static class MouseScrollingEvent extends InputEvent {
+    public static class MouseScrollingEvent extends InputEvent implements Cancellable {
         public static final CancellableEventBus<MouseScrollingEvent> BUS = CancellableEventBus.create(MouseScrollingEvent.class);
 
         private final double deltaX;
@@ -308,7 +309,7 @@ public abstract class InputEvent extends MutableEvent {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     // TODO: Change the 'button' to sub events. - Lex 0422202
-    public static class InteractionKeyMappingTriggered extends InputEvent implements Cancellable {
+    public static class InteractionKeyMappingTriggered extends InputEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<InteractionKeyMappingTriggered> BUS = CancellableEventBus.create(InteractionKeyMappingTriggered.class);
 
         private final int button;

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -9,8 +9,10 @@ import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.lwjgl.glfw.GLFW;
@@ -24,7 +26,9 @@ import org.lwjgl.glfw.GLFW;
  * @see Key
  * @see InteractionKeyMappingTriggered
  */
-public abstract class InputEvent extends Event {
+public abstract class InputEvent extends MutableEvent {
+    public static final EventBus<InputEvent> BUS = EventBus.create(InputEvent.class);
+
     @ApiStatus.Internal
     protected InputEvent() {}
 
@@ -39,6 +43,8 @@ public abstract class InputEvent extends Event {
      * @see Post
      */
     public static abstract class MouseButton extends InputEvent {
+        public static final EventBus<MouseButton> BUS = EventBus.create(MouseButton.class);
+
         private final int button;
         private final int action;
         private final int modifiers;
@@ -96,8 +102,9 @@ public abstract class InputEvent extends Event {
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
-        @Cancelable
-        public static class Pre extends MouseButton {
+        public static class Pre extends MouseButton implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(int button, int action, int modifiers) {
                 super(button, action, modifiers);
@@ -115,6 +122,8 @@ public abstract class InputEvent extends Event {
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
          */
         public static class Post extends MouseButton {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(int button, int action, int modifiers) {
                 super(button, action, modifiers);
@@ -134,8 +143,9 @@ public abstract class InputEvent extends Event {
      *
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
      */
-    @Cancelable
     public static class MouseScrollingEvent extends InputEvent {
+        public static final CancellableEventBus<MouseScrollingEvent> BUS = CancellableEventBus.create(MouseScrollingEvent.class);
+
         private final double deltaX;
         private final double deltaY;
         private final double mouseX;
@@ -214,6 +224,8 @@ public abstract class InputEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Key extends InputEvent {
+        public static final EventBus<Key> BUS = EventBus.create(Key.class);
+
         private final int key;
         private final int scanCode;
         private final int action;
@@ -296,8 +308,9 @@ public abstract class InputEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     // TODO: Change the 'button' to sub events. - Lex 0422202
-    @Cancelable
-    public static class InteractionKeyMappingTriggered extends InputEvent {
+    public static class InteractionKeyMappingTriggered extends InputEvent implements Cancellable {
+        public static final CancellableEventBus<InteractionKeyMappingTriggered> BUS = CancellableEventBus.create(InteractionKeyMappingTriggered.class);
+
         private final int button;
         private final KeyMapping keyMapping;
         private final InteractionHand hand;

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -13,6 +13,8 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraftforge.client.model.geometry.IGeometryLoader;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -48,7 +50,10 @@ public abstract class ModelEvent extends MutableEvent {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<ModifyBakingResult> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, ModifyBakingResult.class);
+        }
+
         private final ModelBakery modelBakery;
         private final ModelBakery.BakingResult results;
 
@@ -85,7 +90,10 @@ public abstract class ModelEvent extends MutableEvent {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class BakingCompleted extends ModelEvent implements IModBusEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<BakingCompleted> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, BakingCompleted.class);
+        }
+
         private final ModelManager modelManager;
         private final ModelBakery modelBakery;
 
@@ -120,7 +128,10 @@ public abstract class ModelEvent extends MutableEvent {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterModelStateDefinitions extends ModelEvent implements IModBusEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<RegisterModelStateDefinitions> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, RegisterModelStateDefinitions.class);
+        }
+
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> states = new HashMap<>();
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> view = Collections.unmodifiableMap(states);
 
@@ -151,7 +162,10 @@ public abstract class ModelEvent extends MutableEvent {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<RegisterGeometryLoaders> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, RegisterGeometryLoaders.class);
+        }
+
         private final Map<ResourceLocation, IGeometryLoader<?>> loaders;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -13,8 +13,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraftforge.client.model.geometry.IGeometryLoader;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -28,7 +27,7 @@ import java.util.Map;
 /**
  * Houses events related to models.
  */
-public abstract class ModelEvent extends Event {
+public abstract class ModelEvent extends MutableEvent {
     @ApiStatus.Internal
     protected ModelEvent() { }
 
@@ -49,6 +48,7 @@ public abstract class ModelEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
         private final ModelBakery modelBakery;
         private final ModelBakery.BakingResult results;
 
@@ -85,6 +85,7 @@ public abstract class ModelEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class BakingCompleted extends ModelEvent implements IModBusEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
         private final ModelManager modelManager;
         private final ModelBakery modelBakery;
 
@@ -119,6 +120,7 @@ public abstract class ModelEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterModelStateDefinitions extends ModelEvent implements IModBusEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> states = new HashMap<>();
         private final Map<ResourceLocation, StateDefinition<Block, BlockState>> view = Collections.unmodifiableMap(states);
 
@@ -149,6 +151,7 @@ public abstract class ModelEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterGeometryLoaders extends ModelEvent implements IModBusEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
         private final Map<ResourceLocation, IGeometryLoader<?>> loaders;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/MovementInputUpdateEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.client.player.ClientInput;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -22,6 +22,8 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class MovementInputUpdateEvent extends PlayerEvent {
+    public static final EventBus<MovementInputUpdateEvent> BUS = EventBus.create(MovementInputUpdateEvent.class);
+
     private final ClientInput input;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -6,10 +6,9 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.ClientRecipeBook;
-import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -21,7 +20,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RecipesUpdatedEvent extends Event {
+public class RecipesUpdatedEvent extends MutableEvent {
+    public static final EventBus<RecipesUpdatedEvent> BUS = EventBus.create(RecipesUpdatedEvent.class);
+
     private final ClientRecipeBook recipeBook;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientCommandsEvent.java
@@ -11,8 +11,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.ObjectiveArgument;
 import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -34,8 +34,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see net.minecraftforge.event.RegisterCommandsEvent
  */
-public class RegisterClientCommandsEvent extends Event
-{
+public class RegisterClientCommandsEvent extends MutableEvent {
+    public static final EventBus<RegisterClientCommandsEvent> BUS = EventBus.create(RegisterClientCommandsEvent.class);
+
     private final CommandDispatcher<CommandSourceStack> dispatcher;
     private final CommandBuildContext context;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
@@ -9,8 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraftforge.event.AddReloadListenerEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -27,8 +26,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterClientReloadListenersEvent extends Event implements IModBusEvent
-{
+public class RegisterClientReloadListenersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final ReloadableResourceManager resourceManager;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientReloadListenersEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraftforge.event.AddReloadListenerEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -27,7 +29,9 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterClientReloadListenersEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterClientReloadListenersEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterClientReloadListenersEvent.class);
+    }
 
     private final ReloadableResourceManager resourceManager;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -26,7 +28,9 @@ import java.util.function.Function;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterClientTooltipComponentFactoriesEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterClientTooltipComponentFactoriesEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterClientTooltipComponentFactoriesEvent.class);
+    }
 
     private final Map<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> factories;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterClientTooltipComponentFactoriesEvent.java
@@ -7,8 +7,7 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -26,8 +25,9 @@ import java.util.function.Function;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterClientTooltipComponentFactoriesEvent extends Event implements IModBusEvent
-{
+public class RegisterClientTooltipComponentFactoriesEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final Map<Class<? extends TooltipComponent>, Function<TooltipComponent, ClientTooltipComponent>> factories;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -10,8 +10,7 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ColorResolver;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -27,7 +26,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RegisterColorHandlersEvent.Block
  * @see RegisterColorHandlersEvent.Item
  */
-public abstract class RegisterColorHandlersEvent extends Event implements IModBusEvent {
+public abstract class RegisterColorHandlersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     @ApiStatus.Internal
     protected RegisterColorHandlersEvent() {}
 
@@ -40,6 +41,8 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Block extends RegisterColorHandlersEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         private final BlockColors blockColors;
 
         @ApiStatus.Internal
@@ -73,6 +76,8 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
      * {@link net.minecraft.world.level.BlockAndTintGetter#getBlockTint(BlockPos, ColorResolver)}.
      */
     public static class ColorResolvers extends RegisterColorHandlersEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         private final ImmutableList.Builder<ColorResolver> builder;
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterColorHandlersEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ColorResolver;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -27,8 +29,6 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RegisterColorHandlersEvent.Item
  */
 public abstract class RegisterColorHandlersEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
-
     @ApiStatus.Internal
     protected RegisterColorHandlersEvent() {}
 
@@ -41,7 +41,9 @@ public abstract class RegisterColorHandlersEvent extends MutableEvent implements
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Block extends RegisterColorHandlersEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<Block> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, Block.class);
+        }
 
         private final BlockColors blockColors;
 
@@ -76,7 +78,9 @@ public abstract class RegisterColorHandlersEvent extends MutableEvent implements
      * {@link net.minecraft.world.level.BlockAndTintGetter#getBlockTint(BlockPos, ColorResolver)}.
      */
     public static class ColorResolvers extends RegisterColorHandlersEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<ColorResolvers> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, ColorResolvers.class);
+        }
 
         private final ImmutableList.Builder<ColorResolver> builder;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -24,7 +26,9 @@ import java.util.Map;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterDimensionSpecialEffectsEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterDimensionSpecialEffectsEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterDimensionSpecialEffectsEvent.class);
+    }
 
     private final Map<ResourceLocation, DimensionSpecialEffects> effects;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterDimensionSpecialEffectsEvent.java
@@ -7,8 +7,7 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -24,8 +23,9 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterDimensionSpecialEffectsEvent extends Event implements IModBusEvent
-{
+public class RegisterDimensionSpecialEffectsEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final Map<ResourceLocation, DimensionSpecialEffects> effects;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -25,6 +27,9 @@ import java.util.Map;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterEntitySpectatorShadersEvent extends MutableEvent implements IModBusEvent {
+    public static EventBus<RegisterEntitySpectatorShadersEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterEntitySpectatorShadersEvent.class);
+    }
     // Todo: [Forge][Event] BUS from mod BusGroup
 
     private final Map<EntityType<?>, ResourceLocation> shaders;

--- a/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterEntitySpectatorShadersEvent.java
@@ -7,8 +7,7 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -25,8 +24,9 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterEntitySpectatorShadersEvent extends Event implements IModBusEvent
-{
+public class RegisterEntitySpectatorShadersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final Map<EntityType<?>, ResourceLocation> shaders;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
@@ -9,8 +9,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.client.IItemDecorator;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -28,8 +27,8 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterItemDecorationsEvent extends Event implements IModBusEvent
-{
+public class RegisterItemDecorationsEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
 
     private final Map<Item, List<IItemDecorator>> decorators;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterItemDecorationsEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.client.IItemDecorator;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -28,7 +30,9 @@ import java.util.Map;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterItemDecorationsEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterItemDecorationsEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterItemDecorationsEvent.class);
+    }
 
     private final Map<Item, List<IItemDecorator>> decorators;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
@@ -7,8 +7,7 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -23,8 +22,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterKeyMappingsEvent extends Event implements IModBusEvent
-{
+public class RegisterKeyMappingsEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final Options options;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterKeyMappingsEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -23,7 +25,9 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterKeyMappingsEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterKeyMappingsEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterKeyMappingsEvent.class);
+    }
 
     private final Options options;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -10,8 +10,7 @@ import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.RenderTypeGroup;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -28,8 +27,9 @@ import java.util.Map;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
-{
+public class RegisterNamedRenderTypesEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final Map<ResourceLocation, RenderTypeGroup> renderTypes;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -10,6 +10,8 @@ import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.RenderTypeGroup;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -28,7 +30,9 @@ import java.util.Map;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterNamedRenderTypesEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterNamedRenderTypesEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterNamedRenderTypesEvent.class);
+    }
 
     private final Map<ResourceLocation, RenderTypeGroup> renderTypes;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -29,7 +31,9 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterParticleProvidersEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterParticleProvidersEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterParticleProvidersEvent.class);
+    }
 
     private final ParticleEngine particleEngine;
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterParticleProvidersEvent.java
@@ -10,8 +10,7 @@ import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.TextureSheetParticle;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -29,8 +28,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterParticleProvidersEvent extends Event implements IModBusEvent
-{
+public class RegisterParticleProvidersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final ParticleEngine particleEngine;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.client.event;
 
 import java.util.Map;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,7 +31,9 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterPresetEditorsEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterPresetEditorsEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterPresetEditorsEvent.class);
+    }
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.client.event;
 
 import java.util.Map;
 
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,8 +15,6 @@ import org.jetbrains.annotations.ApiStatus;
 import net.minecraft.client.gui.screens.worldselection.PresetEditor;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.levelgen.presets.WorldPreset;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -29,8 +28,9 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterPresetEditorsEvent extends Event implements IModBusEvent
-{
+public class RegisterPresetEditorsEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final Map<ResourceKey<WorldPreset>, PresetEditor> editors;

--- a/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
@@ -10,8 +10,7 @@ import com.google.common.collect.BiMap;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.textures.ITextureAtlasSpriteLoader;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -26,7 +25,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RegisterTextureAtlasSpriteLoadersEvent extends Event implements IModBusEvent {
+public class RegisterTextureAtlasSpriteLoadersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final BiMap<ResourceLocation, ITextureAtlasSpriteLoader> loaders;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
@@ -10,6 +10,8 @@ import com.google.common.collect.BiMap;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.textures.ITextureAtlasSpriteLoader;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -26,7 +28,9 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterTextureAtlasSpriteLoadersEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterTextureAtlasSpriteLoadersEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterTextureAtlasSpriteLoadersEvent.class);
+    }
 
     private final BiMap<ResourceLocation, ITextureAtlasSpriteLoader> loaders;
 

--- a/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderArmEvent.java
@@ -6,13 +6,13 @@
 package net.minecraftforge.client.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -27,8 +27,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-@Cancelable
-public class RenderArmEvent extends Event {
+public class RenderArmEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<RenderArmEvent> BUS = CancellableEventBus.create(RenderArmEvent.class);
+
     private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;
     private final int packedLight;

--- a/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBlockScreenEffectEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -24,9 +25,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-@Cancelable
-public class RenderBlockScreenEffectEvent extends Event
-{
+public class RenderBlockScreenEffectEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<RenderBlockScreenEffectEvent> BUS = CancellableEventBus.create(RenderBlockScreenEffectEvent.class);
+
     /**
      * The type of the block overlay to be rendered.
      *

--- a/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
@@ -11,8 +11,9 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -27,9 +28,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see RenderArmEvent
  */
-@Cancelable
-public class RenderHandEvent extends Event
-{
+public class RenderHandEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<RenderHandEvent> BUS = CancellableEventBus.create(RenderHandEvent.class);
+
     private final InteractionHand hand;
     private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;

--- a/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHighlightEvent.java
@@ -13,8 +13,10 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -25,9 +27,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see Block
  * @see Entity
  */
-@Cancelable
-public abstract class RenderHighlightEvent extends Event
-{
+public abstract class RenderHighlightEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<RenderHighlightEvent> BUS = CancellableEventBus.create(RenderHighlightEvent.class);
+
     private final LevelRenderer levelRenderer;
     private final Camera camera;
     private final HitResult target;
@@ -103,9 +105,9 @@ public abstract class RenderHighlightEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Block extends RenderHighlightEvent
-    {
+    public static class Block extends RenderHighlightEvent implements Cancellable {
+        public static final CancellableEventBus<Block> BUS = CancellableEventBus.create(Block.class);
+
         @ApiStatus.Internal
         public Block(LevelRenderer levelRenderer, Camera camera, BlockHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)
         {
@@ -130,8 +132,11 @@ public abstract class RenderHighlightEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Entity extends RenderHighlightEvent
-    {
+    public static class Entity extends RenderHighlightEvent {
+        public static final EventBus<Entity> BUS = EventBus.create(Entity.class);
+
+        // Todo: [Forge][Event] Non-cancellable event inherits from cancellable event, possibly a bug?
+
         @ApiStatus.Internal
         public Entity(LevelRenderer levelRenderer, Camera camera, EntityHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource)
         {

--- a/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
@@ -11,8 +11,9 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.ItemFrameRenderer;
 import net.minecraft.client.renderer.entity.state.ItemFrameRenderState;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -28,8 +29,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see ItemFrameRenderer
  */
-@Cancelable
-public class RenderItemInFrameEvent extends Event {
+public class RenderItemInFrameEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<RenderItemInFrameEvent> BUS = CancellableEventBus.create(RenderItemInFrameEvent.class);
+
     private final ItemFrameRenderState state;
     private final ItemFrameRenderer<?> renderer;
     private final PoseStack poseStack;

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -13,6 +13,7 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
@@ -103,6 +104,8 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      */
     public static class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> implements Cancellable {
         // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
+        public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
         @ApiStatus.Internal
         public Pre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);
@@ -122,6 +125,8 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      */
     public static class Post<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
         // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
         @ApiStatus.Internal
         public Post(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -112,7 +112,7 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
     /**
      * Fired <b>after</b> an entity is rendered, if the corresponding {@link RenderLivingEvent.Post} is not cancelled.
      *
-     * <p>This event is not {@linkplain Cancelable cancelable}, and does not {@linkplain HasResult have a result}.</p>
+     * <p>This event is not {@linkplain Cancellable cancelable}, and does not {@linkplain HasResult have a result}.</p>
      *
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -13,8 +13,8 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -32,7 +32,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent
  * @see LivingEntityRenderer
  */
-public abstract class RenderLivingEvent<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends Event {
+public abstract class RenderLivingEvent<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends MutableEvent {
+    // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
+
     private final S state;
     private final LivingEntityRenderer<T, S, M> renderer;
     private final PoseStack poseStack;
@@ -99,8 +101,8 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <T> the living entity that is being rendered
      * @param <M> the model for the living entity
      */
-    @Cancelable
-    public static class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
+    public static class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> implements Cancellable {
+        // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
         @ApiStatus.Internal
         public Pre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);
@@ -119,6 +121,7 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <M> the model for the living entity
      */
     public static class Post<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
+        // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
         @ApiStatus.Internal
         public Post(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -13,7 +13,6 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
@@ -103,8 +102,6 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <M> the model for the living entity
      */
     public static class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> implements Cancellable {
-        public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
-
         // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
         @ApiStatus.Internal
         public Pre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
@@ -124,8 +121,6 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <M> the model for the living entity
      */
     public static class Post<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
-        public static final EventBus<Post> BUS = EventBus.create(Post.class);
-
         // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
         @ApiStatus.Internal
         public Post(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -13,6 +13,7 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
@@ -102,6 +103,8 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <M> the model for the living entity
      */
     public static class Pre<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> implements Cancellable {
+        public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
         // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
         @ApiStatus.Internal
         public Pre(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
@@ -121,6 +124,8 @@ public abstract class RenderLivingEvent<T extends LivingEntity, S extends Living
      * @param <M> the model for the living entity
      */
     public static class Post<T extends LivingEntity, S extends LivingEntityRenderState, M extends EntityModel<? super S>> extends RenderLivingEvent<T, S, M> {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
         // Todo: [Forge][Event] Not sure how the generics should be handled for this with EventBus v7
         @ApiStatus.Internal
         public Post(S state, LivingEntityRenderer<T, S, M> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {

--- a/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
@@ -11,6 +11,8 @@ import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
@@ -31,8 +33,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see EntityRenderer
  */
-@HasResult
-public class RenderNameTagEvent extends MutableEvent {
+public class RenderNameTagEvent extends MutableEvent implements HasResult {
     public static final EventBus<RenderNameTagEvent> BUS = EventBus.create(RenderNameTagEvent.class);
 
     private Component nameplateContent;
@@ -42,6 +43,7 @@ public class RenderNameTagEvent extends MutableEvent {
     private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;
     private final int packedLight;
+    private Result result = Result.DEFAULT;
 
     @ApiStatus.Internal
     public RenderNameTagEvent(EntityRenderState state, Component content, EntityRenderer<?, ?> entityRenderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
@@ -110,5 +112,15 @@ public class RenderNameTagEvent extends MutableEvent {
      */
     public int getPackedLight() {
         return this.packedLight;
+    }
+
+    @Override
+    public Result getResult() {
+        return this.result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameTagEvent.java
@@ -11,8 +11,8 @@ import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -31,8 +31,10 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see EntityRenderer
  */
-@Event.HasResult
-public class RenderNameTagEvent extends Event {
+@HasResult
+public class RenderNameTagEvent extends MutableEvent {
+    public static final EventBus<RenderNameTagEvent> BUS = EventBus.create(RenderNameTagEvent.class);
+
     private Component nameplateContent;
     private final EntityRenderState state;
     private final Component originalContent;

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -11,8 +11,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.client.renderer.entity.state.PlayerRenderState;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -24,7 +26,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see RenderPlayerEvent.Post
  * @see PlayerRenderer
  */
-public abstract class RenderPlayerEvent extends Event {
+public abstract class RenderPlayerEvent extends MutableEvent {
+    public static final EventBus<RenderPlayerEvent> BUS = EventBus.create(RenderPlayerEvent.class);
+
     private final PlayerRenderState state;
     private final PlayerRenderer renderer;
     private final PoseStack poseStack;
@@ -85,8 +89,9 @@ public abstract class RenderPlayerEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Pre extends RenderPlayerEvent {
+    public static class Pre extends RenderPlayerEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
         @ApiStatus.Internal
         public Pre(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);
@@ -102,6 +107,8 @@ public abstract class RenderPlayerEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Post extends RenderPlayerEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
         @ApiStatus.Internal
         public Post(PlayerRenderState state, PlayerRenderer renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, int packedLight) {
             super(state, renderer, poseStack, multiBufferSource, packedLight);

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -16,8 +16,10 @@ import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -34,8 +36,9 @@ import java.util.List;
  * @see RenderTooltipEvent.Pre
  * @see RenderTooltipEvent.Background
  */
-public abstract class RenderTooltipEvent extends Event
-{
+public abstract class RenderTooltipEvent extends MutableEvent {
+    public static final EventBus<RenderTooltipEvent> BUS = EventBus.create(RenderTooltipEvent.class);
+
     @NotNull
     protected final ItemStack itemStack;
     protected final GuiGraphics graphics;
@@ -120,9 +123,9 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class GatherComponents extends Event
-    {
+    public static class GatherComponents extends MutableEvent implements Cancellable {
+        public static final CancellableEventBus<GatherComponents> BUS = CancellableEventBus.create(GatherComponents.class);
+
         private final ItemStack itemStack;
         private final int screenWidth;
         private final int screenHeight;
@@ -209,9 +212,9 @@ public abstract class RenderTooltipEvent extends Event
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Pre extends RenderTooltipEvent
-    {
+    public static class Pre extends RenderTooltipEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
         private final int screenWidth;
         private final int screenHeight;
         private final ClientTooltipPositioner positioner;
@@ -290,6 +293,8 @@ public abstract class RenderTooltipEvent extends Event
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Background extends RenderTooltipEvent {
+        public static final EventBus<Background> BUS = EventBus.create(Background.class);
+
         private final ResourceLocation originalBackground;
         private ResourceLocation background;
 

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
@@ -427,11 +429,11 @@ public abstract class ScreenEvent extends MutableEvent {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @HasResult
-        public static class Post extends MouseButtonPressed {
+        public static class Post extends MouseButtonPressed implements HasResult {
             public static final EventBus<Post> BUS = EventBus.create(Post.class);
 
             private final boolean handled;
+            private Result result = Result.DEFAULT;
 
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, int button, boolean handled) {
@@ -444,6 +446,16 @@ public abstract class ScreenEvent extends MutableEvent {
              */
             public boolean wasHandled() {
                 return handled;
+            }
+
+            @Override
+            public Result getResult() {
+                return result;
+            }
+
+            @Override
+            public void setResult(Result result) {
+                this.result = result;
             }
         }
     }
@@ -510,11 +522,11 @@ public abstract class ScreenEvent extends MutableEvent {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @HasResult
-        public static class Post extends MouseButtonReleased {
+        public static class Post extends MouseButtonReleased implements HasResult {
             public static final EventBus<Post> BUS = EventBus.create(Post.class);
 
             private final boolean handled;
+            private Result result = Result.DEFAULT;
 
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, int button, boolean handled) {
@@ -527,6 +539,16 @@ public abstract class ScreenEvent extends MutableEvent {
              */
             public boolean wasHandled() {
                 return handled;
+            }
+
+            @Override
+            public Result getResult() {
+                return result;
+            }
+
+            @Override
+            public void setResult(Result result) {
+                this.result = result;
             }
         }
     }

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -111,11 +111,11 @@ public abstract class ScreenEvent extends MutableEvent {
         /**
          * Fired <b>before</b> the screen's overridable initialization method is fired.
          *
-         * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
+         * <p>This event is {@linkplain Cancellable cancellable}, and does not {@linkplain HasResult have a result}.
          * If the event is cancelled, the initialization method will not be called, and the widgets and children lists
          * will not be cleared.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain Pre#BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends Init implements Cancellable {
@@ -130,9 +130,9 @@ public abstract class ScreenEvent extends MutableEvent {
         /**
          * Fired <b>after</b> the screen's overridable initialization method is called.
          *
-         * <p>This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.</p>
+         * <p>This event is not {@linkplain Cancellable cancellable}, and does not {@linkplain HasResult have a result}.</p>
          *
-         * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain Post#BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends Init {

--- a/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenEvent.java
@@ -10,8 +10,10 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -35,7 +37,9 @@ import java.util.function.Consumer;
  * @see MouseInput
  * @see KeyInput
  */
-public abstract class ScreenEvent extends Event {
+public abstract class ScreenEvent extends MutableEvent {
+    public static final EventBus<ScreenEvent> BUS = EventBus.create(ScreenEvent.class);
+
     private final Screen screen;
 
     @ApiStatus.Internal
@@ -62,6 +66,8 @@ public abstract class ScreenEvent extends Event {
      * @see Init.Post
      */
     public static abstract class Init extends ScreenEvent {
+        public static final EventBus<Init> BUS = EventBus.create(Init.class);
+
         private final Consumer<GuiEventListener> add;
         private final Consumer<GuiEventListener> remove;
 
@@ -110,8 +116,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends Init {
+        public static class Pre extends Init implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
                 super(screen, list, add, remove);
@@ -127,6 +134,8 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends Init {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, List<GuiEventListener> list, Consumer<GuiEventListener> add, Consumer<GuiEventListener> remove) {
                 super(screen, list, add, remove);
@@ -142,6 +151,8 @@ public abstract class ScreenEvent extends Event {
      * @see Render.Post
      */
     public static abstract class Render extends ScreenEvent {
+        public static final EventBus<Render> BUS = EventBus.create(Render.class);
+
         private final GuiGraphics guiGraphics;
         private final int mouseX;
         private final int mouseY;
@@ -193,8 +204,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends Render {
+        public static class Pre extends Render implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
                 super(screen, guiGraphics, mouseX, mouseY, partialTick);
@@ -210,6 +222,8 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends Render {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
                 super(screen, guiGraphics, mouseX, mouseY, partialTick);
@@ -227,6 +241,8 @@ public abstract class ScreenEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class BackgroundRendered extends ScreenEvent {
+        public static final EventBus<BackgroundRendered> BUS = EventBus.create(BackgroundRendered.class);
+
         private final GuiGraphics guiGraphics;
 
         @ApiStatus.Internal
@@ -254,8 +270,9 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class RenderInventoryMobEffects extends ScreenEvent {
+    public static class RenderInventoryMobEffects extends ScreenEvent implements Cancellable {
+        public static final CancellableEventBus<RenderInventoryMobEffects> BUS = CancellableEventBus.create(RenderInventoryMobEffects.class);
+
         private final int availableSpace;
         private boolean compact;
         private int horizontalOffset;
@@ -321,6 +338,8 @@ public abstract class ScreenEvent extends Event {
      * @see MouseScrolled
      */
     private static abstract class MouseInput extends ScreenEvent {
+        public static final EventBus<MouseInput> BUS = EventBus.create(MouseInput.class);
+
         private final double mouseX;
         private final double mouseY;
 
@@ -354,6 +373,8 @@ public abstract class ScreenEvent extends Event {
      * @see MouseButtonPressed.Post
      */
     public static abstract class MouseButtonPressed extends MouseInput {
+        public static final EventBus<MouseButtonPressed> BUS = EventBus.create(MouseButtonPressed.class);
+
         private final int button;
 
         @ApiStatus.Internal
@@ -382,8 +403,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseButtonPressed {
+        public static class Pre extends MouseButtonPressed implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int button) {
                 super(screen, mouseX, mouseY, button);
@@ -407,6 +429,8 @@ public abstract class ScreenEvent extends Event {
          */
         @HasResult
         public static class Post extends MouseButtonPressed {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             private final boolean handled;
 
             @ApiStatus.Internal
@@ -432,6 +456,8 @@ public abstract class ScreenEvent extends Event {
      * @see MouseButtonReleased.Post
      */
     public static abstract class MouseButtonReleased extends MouseInput {
+        public static final EventBus<MouseButtonReleased> BUS = EventBus.create(MouseButtonReleased.class);
+
         private final int button;
 
         @ApiStatus.Internal
@@ -460,8 +486,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseButtonReleased {
+        public static class Pre extends MouseButtonReleased implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int button) {
                 super(screen, mouseX, mouseY, button);
@@ -485,6 +512,8 @@ public abstract class ScreenEvent extends Event {
          */
         @HasResult
         public static class Post extends MouseButtonReleased {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             private final boolean handled;
 
             @ApiStatus.Internal
@@ -510,6 +539,8 @@ public abstract class ScreenEvent extends Event {
      * @see MouseDragged.Post
      */
     public static abstract class MouseDragged extends MouseInput {
+        public static final EventBus<MouseDragged> BUS = EventBus.create(MouseDragged.class);
+
         private final int mouseButton;
         private final double dragX;
         private final double dragY;
@@ -556,8 +587,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseDragged {
+        public static class Pre extends MouseDragged implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
                 super(screen, mouseX, mouseY, mouseButton, dragX, dragY);
@@ -575,6 +607,8 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends MouseDragged {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
                 super(screen, mouseX, mouseY, mouseButton, dragX, dragY);
@@ -590,6 +624,8 @@ public abstract class ScreenEvent extends Event {
      * @see MouseScrolled.Post
      */
     public static abstract class MouseScrolled extends MouseInput {
+        public static final EventBus<MouseScrolled> BUS = EventBus.create(MouseScrolled.class);
+
         private final double deltaX;
         private final double deltaY;
 
@@ -624,8 +660,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends MouseScrolled {
+        public static class Pre extends MouseScrolled implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
                 super(screen, mouseX, mouseY, deltaX, deltaY);
@@ -643,6 +680,8 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends MouseScrolled {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, double mouseX, double mouseY, double deltaX, double deltaY) {
                 super(screen, mouseX, mouseY, deltaX, deltaY);
@@ -660,6 +699,8 @@ public abstract class ScreenEvent extends Event {
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_key" target="_top">the online GLFW documentation</a>
      */
     private static abstract class KeyInput extends ScreenEvent {
+        public static final EventBus<KeyInput> BUS = EventBus.create(KeyInput.class);
+
         private final int keyCode;
         private final int scanCode;
         private final int modifiers;
@@ -720,6 +761,8 @@ public abstract class ScreenEvent extends Event {
      * @see KeyPressed.Post
      */
     public static abstract class KeyPressed extends KeyInput {
+        public static final EventBus<KeyPressed> BUS = EventBus.create(KeyPressed.class);
+
         @ApiStatus.Internal
         public KeyPressed(Screen screen, int keyCode, int scanCode, int modifiers) {
             super(screen, keyCode, scanCode, modifiers);
@@ -735,8 +778,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends KeyPressed {
+        public static class Pre extends KeyPressed implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -753,8 +797,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Post extends KeyPressed {
+        public static class Post extends KeyPressed implements Cancellable {
+            public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -770,6 +815,8 @@ public abstract class ScreenEvent extends Event {
      * @see KeyReleased.Post
      */
     public static abstract class KeyReleased extends KeyInput {
+        public static final EventBus<KeyReleased> BUS = EventBus.create(KeyReleased.class);
+
         @ApiStatus.Internal
         public KeyReleased(Screen screen, int keyCode, int scanCode, int modifiers) {
             super(screen, keyCode, scanCode, modifiers);
@@ -785,8 +832,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends KeyReleased {
+        public static class Pre extends KeyReleased implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -803,8 +851,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Post extends KeyReleased {
+        public static class Post extends KeyReleased implements Cancellable {
+            public static final CancellableEventBus<Post> BUS = CancellableEventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, int keyCode, int scanCode, int modifiers) {
                 super(screen, keyCode, scanCode, modifiers);
@@ -821,6 +870,8 @@ public abstract class ScreenEvent extends Event {
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_char" target="_top">the online GLFW documentation</a>
      */
     public static class CharacterTyped extends ScreenEvent {
+        public static final EventBus<CharacterTyped> BUS = EventBus.create(CharacterTyped.class);
+
         private final char codePoint;
         private final int modifiers;
 
@@ -863,8 +914,9 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
-        @Cancelable
-        public static class Pre extends CharacterTyped {
+        public static class Pre extends CharacterTyped implements Cancellable {
+            public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
             @ApiStatus.Internal
             public Pre(Screen screen, char codePoint, int modifiers) {
                 super(screen, codePoint, modifiers);
@@ -882,6 +934,8 @@ public abstract class ScreenEvent extends Event {
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends CharacterTyped {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             @ApiStatus.Internal
             public Post(Screen screen, char codePoint, int modifiers) {
                 super(screen, codePoint, modifiers);
@@ -901,8 +955,9 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class Opening extends ScreenEvent {
+    public static class Opening extends ScreenEvent implements Cancellable {
+        public static final CancellableEventBus<Opening> BUS = CancellableEventBus.create(Opening.class);
+
         @Nullable
         private final Screen currentScreen;
         private Screen newScreen;
@@ -950,6 +1005,8 @@ public abstract class ScreenEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Closing extends ScreenEvent {
+        public static final EventBus<Closing> BUS = EventBus.create(Closing.class);
+
         @ApiStatus.Internal
         public Closing(Screen screen) {
             super(screen);

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -9,8 +9,9 @@ import com.mojang.blaze3d.platform.NativeImage;
 import net.minecraft.client.Screenshot;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -29,9 +30,9 @@ import java.io.IOException;
  *
  * @see Screenshot
  */
-@Cancelable
-public class ScreenshotEvent extends Event
-{
+public class ScreenshotEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ScreenshotEvent> BUS = CancellableEventBus.create(ScreenshotEvent.class);
+
     public static final Component DEFAULT_CANCEL_REASON = Component.literal("Screenshot canceled");
 
     private final NativeImage image;

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.platform.NativeImage;
 import net.minecraft.client.Screenshot;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
@@ -30,7 +31,7 @@ import java.io.IOException;
  *
  * @see Screenshot
  */
-public class ScreenshotEvent extends MutableEvent implements Cancellable {
+public class ScreenshotEvent extends MutableEvent implements Cancellable, CancellableAware {
     public static final CancellableEventBus<ScreenshotEvent> BUS = CancellableEventBus.create(ScreenshotEvent.class);
 
     public static final Component DEFAULT_CANCEL_REASON = Component.literal("Screenshot canceled");

--- a/src/main/java/net/minecraftforge/client/event/SystemMessageReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/SystemMessageReceivedEvent.java
@@ -6,8 +6,9 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -17,8 +18,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>If the event is cancelled, the message is not displayed in the chat message window.</p>
  *
  */
-@Cancelable
-public class SystemMessageReceivedEvent extends Event {
+public class SystemMessageReceivedEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<SystemMessageReceivedEvent> BUS = CancellableEventBus.create(SystemMessageReceivedEvent.class);
+
     private Component message;
     private final boolean overlay;
 

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -6,8 +6,7 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.renderer.texture.TextureAtlas;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -19,8 +18,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see TextureStitchEvent.Post
  * @see TextureAtlas
  */
-public class TextureStitchEvent extends Event implements IModBusEvent
-{
+public class TextureStitchEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final TextureAtlas atlas;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -19,8 +21,6 @@ import org.jetbrains.annotations.ApiStatus;
  * @see TextureAtlas
  */
 public class TextureStitchEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
-
     private final TextureAtlas atlas;
 
     @ApiStatus.Internal
@@ -80,8 +80,11 @@ public class TextureStitchEvent extends MutableEvent implements IModBusEvent {
      * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus()} mod-specific event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    public static class Post extends TextureStitchEvent
-    {
+    public static class Post extends TextureStitchEvent {
+        public static EventBus<Post> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, Post.class);
+        }
+
         @ApiStatus.Internal
         public Post(TextureAtlas map)
         {

--- a/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ToastAddEvent.java
@@ -7,8 +7,9 @@ package net.minecraftforge.client.event;
 
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -21,8 +22,9 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-@Cancelable
-public class ToastAddEvent extends Event {
+public class ToastAddEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ToastAddEvent> BUS = CancellableEventBus.create(ToastAddEvent.class);
+
     private final Toast toast;
 
     public ToastAddEvent(Toast toast) {

--- a/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ViewportEvent.java
@@ -12,8 +12,10 @@ import net.minecraft.client.renderer.FogRenderer.FogMode;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.world.level.material.FogType;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -30,7 +32,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see ComputeCameraAngles
  * @see ComputeFov
  */
-public abstract class ViewportEvent extends Event {
+public abstract class ViewportEvent extends MutableEvent {
+    public static final EventBus<ViewportEvent> BUS = EventBus.create(ViewportEvent.class);
+
     private final GameRenderer renderer;
     private final Camera camera;
     private final double partialTick;
@@ -72,8 +76,9 @@ public abstract class ViewportEvent extends Event {
      * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
-    @Cancelable
-    public static class RenderFog extends ViewportEvent {
+    public static class RenderFog extends ViewportEvent implements Cancellable {
+        public static final CancellableEventBus<RenderFog> BUS = CancellableEventBus.create(RenderFog.class);
+
         private final FogMode mode;
         private final FogType type;
         private float farPlaneDistance;
@@ -183,6 +188,8 @@ public abstract class ViewportEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class ComputeFogColor extends ViewportEvent {
+        public static final EventBus<ComputeFogColor> BUS = EventBus.create(ComputeFogColor.class);
+
         private float red;
         private float green;
         private float blue;
@@ -255,6 +262,8 @@ public abstract class ViewportEvent extends Event {
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class ComputeCameraAngles extends ViewportEvent {
+        public static final EventBus<ComputeCameraAngles> BUS = EventBus.create(ComputeCameraAngles.class);
+
         private float yaw;
         private float pitch;
         private float roll;
@@ -328,6 +337,8 @@ public abstract class ViewportEvent extends Event {
      * @see ComputeFovModifierEvent
      */
     public static class ComputeFov extends ViewportEvent {
+        public static final EventBus<ComputeFov> BUS = EventBus.create(ComputeFov.class);
+
         private final boolean usedConfiguredFov;
         private float fov;
 

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.client.event.sound;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -27,8 +27,9 @@ import org.jetbrains.annotations.Nullable;
  * @see PlaySoundSourceEvent
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundEvent extends SoundEvent
-{
+public class PlaySoundEvent extends SoundEvent {
+    public static final EventBus<PlaySoundEvent> BUS = EventBus.create(PlaySoundEvent.class);
+
     private final String name;
     private final SoundInstance originalSound;
     @Nullable

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
@@ -10,7 +10,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.client.event.sound.SoundEvent.SoundSourceEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -26,8 +26,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlaySoundSourceEvent extends SoundSourceEvent
-{
+public class PlaySoundSourceEvent extends SoundSourceEvent {
+    public static final EventBus<PlaySoundSourceEvent> BUS = EventBus.create(PlaySoundSourceEvent.class);
+
     @ApiStatus.Internal
     public PlaySoundSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)
     {

--- a/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -10,7 +10,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraftforge.client.event.sound.SoundEvent.SoundSourceEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -26,8 +26,9 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @see PlayStreamingSourceEvent
  */
-public class PlayStreamingSourceEvent extends SoundSourceEvent
-{
+public class PlayStreamingSourceEvent extends SoundSourceEvent {
+    public static final EventBus<PlayStreamingSourceEvent> BUS = EventBus.create(PlayStreamingSourceEvent.class);
+
     @ApiStatus.Internal
     public PlayStreamingSourceEvent(SoundEngine engine, SoundInstance sound, Channel channel)
     {

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.client.event.sound;
 
 import net.minecraft.client.sounds.SoundEngine;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -21,7 +23,10 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent {
-    // Todo: [Forge][Event] SoundEngineLoadEvent.BUS from mod BusGroup
+    public static EventBus<SoundEngineLoadEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, SoundEngineLoadEvent.class);
+    }
+
     @ApiStatus.Internal
     public SoundEngineLoadEvent(SoundEngine manager)
     {

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEngineLoadEvent.java
@@ -6,7 +6,6 @@
 package net.minecraftforge.client.event.sound;
 
 import net.minecraft.client.sounds.SoundEngine;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -21,8 +20,8 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent
-{
+public class SoundEngineLoadEvent extends SoundEvent implements IModBusEvent {
+    // Todo: [Forge][Event] SoundEngineLoadEvent.BUS from mod BusGroup
     @ApiStatus.Internal
     public SoundEngineLoadEvent(SoundEngine manager)
     {

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import com.mojang.blaze3d.audio.Channel;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -23,8 +24,9 @@ import org.jetbrains.annotations.ApiStatus;
  * @see PlaySoundEvent
  * @see SoundEngineLoadEvent
  */
-public abstract class SoundEvent extends Event
-{
+public abstract class SoundEvent extends MutableEvent {
+    public static final EventBus<SoundEvent> BUS = EventBus.create(SoundEvent.class);
+
     private final SoundEngine engine;
 
     @ApiStatus.Internal
@@ -50,8 +52,9 @@ public abstract class SoundEvent extends Event
      * @see PlaySoundSourceEvent
      * @see PlayStreamingSourceEvent
      */
-    public static abstract class SoundSourceEvent extends SoundEvent
-    {
+    public static abstract class SoundSourceEvent extends SoundEvent {
+        public static final EventBus<SoundSourceEvent> BUS = EventBus.create(SoundSourceEvent.class);
+
         private final SoundInstance sound;
         private final Channel channel;
         private final String name;

--- a/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/client/loading/ClientModLoader.java
@@ -14,6 +14,7 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.world.level.DataPackConfig;
 import net.minecraftforge.event.AddPackFindersEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.*;
 import net.minecraftforge.fml.loading.ImmediateWindowHandler;
 import net.minecraftforge.internal.BrandingControl;
@@ -108,7 +109,7 @@ public class ClientModLoader {
         File dumpedLocation = null;
         if (error == null) {
             // We can finally start the forge eventbus up
-            MinecraftForge.EVENT_BUS.start();
+            BusGroup.DEFAULT.startup();
         } else {
             // Double check we have the langs loaded for forge
             LanguageHook.loadForgeAndMCLangs();

--- a/src/main/java/net/minecraftforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/minecraftforge/client/model/data/ModelDataManager.java
@@ -13,7 +13,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.level.ChunkEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/net/minecraftforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/minecraftforge/client/model/data/ModelDataManager.java
@@ -11,11 +11,7 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.level.ChunkEvent;
-import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * Users should not be instantiating or using this themselves unless they know what they're doing.
  */
 @ApiStatus.Internal
-@EventBusSubscriber(modid = "forge", bus = Bus.FORGE, value = Dist.CLIENT)
 public class ModelDataManager {
     private final Level level;
     private final Map<ChunkPos, Set<BlockPos>> needModelDataRefresh = new ConcurrentHashMap<>();
@@ -82,7 +77,6 @@ public class ModelDataManager {
         return modelDataCache.getOrDefault(pos, Collections.emptyMap());
     }
 
-    @SubscribeEvent
     public static void onChunkUnload(ChunkEvent.Unload event) {
         var level = event.getChunk().getWorldForge();
         if (level == null)

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.common;
 
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
 import org.apache.commons.lang3.tuple.Pair;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1104,8 +1104,7 @@ public final class ForgeHooks {
 
         // Should we always fire this, even if the channel consumed the packet?
         if (!event.getSource().getPacketHandled()) {
-            // Todo: [Forge][Networking] Adjust this to use the new event bus system
-//            MinecraftForge.EVENT_BUS.post(event);
+            CustomPayloadEvent.BUS.post(event);
             return event.getSource().getPacketHandled();
         }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -121,11 +121,7 @@ import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraftforge.common.crafting.conditions.ConditionCodec;
 import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.common.crafting.ingredients.IIngredientSerializer;
-import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.common.util.BrainBuilder;
-import net.minecraftforge.common.util.Lazy;
-import net.minecraftforge.common.util.MavenVersionStringHelper;
-import net.minecraftforge.common.util.MutableHashedLinkedMap;
+import net.minecraftforge.common.util.*;
 import net.minecraftforge.entity.IEntityAdditionalSpawnData;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
@@ -154,7 +150,6 @@ import net.minecraftforge.event.entity.living.LivingGetProjectileEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.NoteBlockEvent;
 import net.minecraftforge.event.network.CustomPayloadEvent;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModList;
@@ -220,31 +215,30 @@ public final class ForgeHooks {
 
     public static Brain<?> onLivingMakeBrain(LivingEntity entity, Brain<?> originalBrain, Dynamic<?> dynamic) {
         BrainBuilder<?> brainBuilder = originalBrain.createBuilder();
-        LivingMakeBrainEvent event = new LivingMakeBrainEvent(entity, brainBuilder);
-        MinecraftForge.EVENT_BUS.post(event);
+        LivingMakeBrainEvent.BUS.post(new LivingMakeBrainEvent(entity, brainBuilder));
         return brainBuilder.makeBrain(dynamic);
     }
 
     public static boolean onLivingAttack(LivingEntity entity, DamageSource src, float amount) {
-        return entity instanceof Player || !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
+        return entity instanceof Player || !LivingAttackEvent.BUS.post(new LivingAttackEvent(entity, src, amount));
     }
 
     public static boolean onPlayerAttack(LivingEntity entity, DamageSource src, float amount) {
-        return !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
+        return !LivingAttackEvent.BUS.post(new LivingAttackEvent(entity, src, amount));
     }
 
     public static boolean onLivingUseTotem(LivingEntity entity, DamageSource damageSource, ItemStack totem, InteractionHand hand) {
-        return !MinecraftForge.EVENT_BUS.post(new LivingUseTotemEvent(entity, damageSource, totem, hand));
+        return !LivingUseTotemEvent.BUS.post(new LivingUseTotemEvent(entity, damageSource, totem, hand));
     }
 
     public static float onLivingHurt(LivingEntity entity, DamageSource src, float amount) {
         LivingHurtEvent event = new LivingHurtEvent(entity, src, amount);
-        return (MinecraftForge.EVENT_BUS.post(event) ? 0 : event.getAmount());
+        return (LivingHurtEvent.BUS.post(event) ? 0 : event.getAmount());
     }
 
     public static float onLivingDamage(LivingEntity entity, DamageSource src, float amount) {
         LivingDamageEvent event = new LivingDamageEvent(entity, src, amount);
-        return (MinecraftForge.EVENT_BUS.post(event) ? 0 : event.getAmount());
+        return (LivingDamageEvent.BUS.post(event) ? 0 : event.getAmount());
     }
 
     public static InteractionResult onInteractEntityAt(Entity entity, Player player, Vec3 vec3d, InteractionHand hand) {
@@ -266,9 +260,8 @@ public final class ForgeHooks {
     }
 
     public static double getEntityVisibilityMultiplier(LivingEntity entity, Entity lookingEntity, double originalMultiplier){
-        LivingEvent.LivingVisibilityEvent event = new LivingEvent.LivingVisibilityEvent(entity, lookingEntity, originalMultiplier);
-        MinecraftForge.EVENT_BUS.post(event);
-        return Math.max(0,event.getVisibilityModifier());
+        var event = LivingEvent.LivingVisibilityEvent.BUS.fire(new LivingEvent.LivingVisibilityEvent(entity, lookingEntity, originalMultiplier));
+        return Math.max(0, event.getVisibilityModifier());
     }
 
     public static Optional<BlockPos> isLivingOnLadder(@NotNull BlockState state, @NotNull Level level, @NotNull BlockPos pos, @NotNull LivingEntity entity) {
@@ -296,7 +289,7 @@ public final class ForgeHooks {
     }
 
     public static void onLivingJump(LivingEntity entity) {
-        MinecraftForge.EVENT_BUS.post(new LivingJumpEvent(entity));
+        LivingJumpEvent.BUS.post(new LivingJumpEvent(entity));
     }
 
     @SuppressWarnings("resource")
@@ -310,7 +303,7 @@ public final class ForgeHooks {
             return null;
 
         ItemTossEvent event = new ItemTossEvent(ret, player);
-        if (MinecraftForge.EVENT_BUS.post(event))
+        if (ItemTossEvent.BUS.post(event))
             return null;
 
         if (!player.level().isClientSide)
@@ -322,7 +315,7 @@ public final class ForgeHooks {
     public static Component onServerChatSubmittedEvent(ServerPlayer player, Component message) {
         var plain = message.getContents() instanceof LiteralContents literalContents ? literalContents.text() : "";
         ServerChatEvent event = new ServerChatEvent(player, plain, message);
-        return MinecraftForge.EVENT_BUS.post(event) ? null : event.getMessage();
+        return ServerChatEvent.BUS.post(event) ? null : event.getMessage();
     }
 
     static final Pattern URL_PATTERN = Pattern.compile(
@@ -424,7 +417,7 @@ public final class ForgeHooks {
 
         var event = new BlockEvent.BreakEvent(level, pos, state, entityPlayer);
         event.setCanceled(preCancelEvent);
-        MinecraftForge.EVENT_BUS.post(event);
+        BlockEvent.BreakEvent.BUS.post(event);
 
         // Handle if the event is canceled
         if (event.isCanceled()) {
@@ -510,7 +503,7 @@ public final class ForgeHooks {
 
     public static boolean onAnvilChange(AnvilMenu container, @NotNull ItemStack left, @NotNull ItemStack right, Container outputSlot, String name, long baseCost, Player player) {
         AnvilUpdateEvent e = new AnvilUpdateEvent(left, right, name, baseCost, player);
-        if (MinecraftForge.EVENT_BUS.post(e)) return false;
+        if (AnvilUpdateEvent.BUS.post(e)) return false;
         if (e.getOutput().isEmpty()) return true;
 
         outputSlot.setItem(0, e.getOutput());
@@ -523,7 +516,7 @@ public final class ForgeHooks {
         access.execute((l,p) -> {
             int xp = xpFunction.apply(l);
             GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(inputSlots.getItem(0), inputSlots.getItem(1), xp);
-            if (MinecraftForge.EVENT_BUS.post(e))
+            if (GrindstoneEvent.OnTakeItem.BUS.post(e))
                 return;
 
             if (l instanceof ServerLevel server)
@@ -561,7 +554,7 @@ public final class ForgeHooks {
     }
 
     public static boolean onPlayerAttackTarget(Player player, Entity target) {
-        if (MinecraftForge.EVENT_BUS.post(new AttackEntityEvent(player, target))) return false;
+        if (AttackEntityEvent.BUS.post(new AttackEntityEvent(player, target))) return false;
         ItemStack stack = player.getMainHandItem();
         return stack.isEmpty() || !stack.getItem().onLeftClickEntity(stack, player, target);
     }
@@ -576,7 +569,7 @@ public final class ForgeHooks {
             return currentGameType;
 
         var evt = new PlayerEvent.PlayerChangeGameModeEvent(player, currentGameType, newGameType);
-        if (MinecraftForge.EVENT_BUS.post(evt))
+        if (PlayerEvent.PlayerChangeGameModeEvent.BUS.post(evt))
             return currentGameType;
 
         return evt.getNewGameMode();
@@ -637,19 +630,19 @@ public final class ForgeHooks {
     }
 
     public static boolean onCropsGrowPre(Level level, BlockPos pos, BlockState state, boolean def) {
-        var result = MinecraftForge.EVENT_BUS.fire(new BlockEvent.CropGrowEvent.Pre(level,pos,state)).getResult();
+        var result = BlockEvent.CropGrowEvent.Pre.BUS.fire(new BlockEvent.CropGrowEvent.Pre(level,pos,state)).getResult();
         return (result.isAllowed() || (def && result.isDefault()));
     }
 
     public static void onCropsGrowPost(Level level, BlockPos pos, BlockState state) {
-        MinecraftForge.EVENT_BUS.post(new BlockEvent.CropGrowEvent.Post(level, pos, state, level.getBlockState(pos)));
+        BlockEvent.CropGrowEvent.Post.BUS.post(new BlockEvent.CropGrowEvent.Post(level, pos, state, level.getBlockState(pos)));
     }
 
     @Nullable
     public static CriticalHitEvent getCriticalHit(Player player, Entity target, boolean vanillaCritical, float damageModifier) {
         CriticalHitEvent hitResult = new CriticalHitEvent(player, target, damageModifier, vanillaCritical);
-        MinecraftForge.EVENT_BUS.post(hitResult);
-        if (hitResult.getResult() == Event.Result.ALLOW || (vanillaCritical && hitResult.getResult() == Event.Result.DEFAULT))
+        CriticalHitEvent.BUS.post(hitResult);
+        if (hitResult.getResult() == Result.ALLOW || (vanillaCritical && hitResult.getResult() == Result.DEFAULT))
             return hitResult;
         return null;
     }
@@ -658,8 +651,7 @@ public final class ForgeHooks {
      * Hook to fire {@link LivingGetProjectileEvent}. Returns the ammo to be used.
      */
     public static ItemStack getProjectile(LivingEntity entity, ItemStack projectileWeaponItem, ItemStack projectile) {
-        LivingGetProjectileEvent event = new LivingGetProjectileEvent(entity, projectileWeaponItem, projectile);
-        MinecraftForge.EVENT_BUS.post(event);
+        var event = LivingGetProjectileEvent.BUS.fire(new LivingGetProjectileEvent(entity, projectileWeaponItem, projectile));
         return event.getProjectileItemStack();
     }
 
@@ -701,7 +693,7 @@ public final class ForgeHooks {
 
     public static int onNoteChange(Level level, BlockPos pos, BlockState state, int old, int _new) {
         NoteBlockEvent.Change event = new NoteBlockEvent.Change(level, pos, state, old, _new);
-        if (MinecraftForge.EVENT_BUS.post(event))
+        if (NoteBlockEvent.Change.BUS.post(event))
             return -1;
         return event.getVanillaNoteId();
     }
@@ -945,13 +937,13 @@ public final class ForgeHooks {
                 return true;
 
             var mask = player.getItemBySlot(EquipmentSlot.HEAD);
-            return !mask.isMonsterDisguise(player, monster) || MinecraftForge.EVENT_BUS.post(new MonsterDisguiseEvent(monster, player));
+            return !mask.isMonsterDisguise(player, monster) || MonsterDisguiseEvent.BUS.post(new MonsterDisguiseEvent(monster, player));
         };
     }
 
     private static final Lazy<Map<String, StructuresBecomeConfiguredFix.Conversion>> FORGE_CONVERSION_MAP = Lazy.concurrentOf(() -> {
         Map<String, StructuresBecomeConfiguredFix.Conversion> map = new HashMap<>();
-        MinecraftForge.EVENT_BUS.post(new RegisterStructureConversionsEvent(map));
+        RegisterStructureConversionsEvent.BUS.post(new RegisterStructureConversionsEvent(map));
         return ImmutableMap.copyOf(map);
     });
 
@@ -1112,7 +1104,8 @@ public final class ForgeHooks {
 
         // Should we always fire this, even if the channel consumed the packet?
         if (!event.getSource().getPacketHandled()) {
-            MinecraftForge.EVENT_BUS.post(event);
+            // Todo: [Forge][Networking] Adjust this to use the new event bus system
+//            MinecraftForge.EVENT_BUS.post(event);
             return event.getSource().getPacketHandled();
         }
 

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -19,8 +19,9 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.event.network.ConnectionStartEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.listener.Priority;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.event.TickEvent.ServerTickEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.network.filters.NetworkFilters;
@@ -29,9 +30,15 @@ import net.minecraftforge.server.command.ForgeCommand;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
 import net.minecraftforge.server.command.ConfigCommand;
 
+import java.lang.invoke.MethodHandles;
+
 public class ForgeInternalHandler {
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    public void onEntityJoinWorld(EntityJoinLevelEvent event) {
+    public void register() {
+        BusGroup.DEFAULT.register(MethodHandles.lookup(), this);
+    }
+
+    @SubscribeEvent(priority = Priority.HIGH)
+    public boolean onEntityJoinWorld(EntityJoinLevelEvent event) {
         Entity entity = event.getEntity();
         if (entity.getClass().equals(ItemEntity.class)) {
             ItemStack stack = ((ItemEntity)entity).getItem();
@@ -40,13 +47,14 @@ public class ForgeInternalHandler {
                 Entity newEntity = item.createEntity(event.getLevel(), entity, stack);
                 if (newEntity != null) {
                     entity.discard();
-                    event.setCanceled(true);
                     @SuppressWarnings("resource")
                     var executor = LogicalSidedProvider.WORKQUEUE.get(event.getLevel().isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER);
                     executor.schedule(new TickTask(0, () -> event.getLevel().addFreshEntity(newEntity)));
+                    return true;
                 }
             }
         }
+        return false;
     }
 
     @SubscribeEvent
@@ -109,10 +117,12 @@ public class ForgeInternalHandler {
         event.addListener(CreativeModeTabRegistry.getReloadListener());
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public void builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
-        if(event.getEntity() instanceof Mob mob && mob.isSpawnCancelled())
-            event.setCanceled(true);
+    @SubscribeEvent(priority = Priority.HIGHEST)
+    public boolean builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
+        if (event.getEntity() instanceof Mob mob && mob.isSpawnCancelled())
+            return true;
+
+        return false;
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -63,6 +63,8 @@ import net.minecraftforge.common.world.NoneStructureModifier;
 import net.minecraftforge.common.world.StructureModifier;
 import net.minecraftforge.event.network.GatherLoginConfigurationTasksEvent;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
@@ -118,6 +120,7 @@ import com.mojang.serialization.MapCodec;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -383,25 +386,28 @@ public class ForgeMod {
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 
         // Todo: [Forge][ForgeMod] mod bus registrations
-//        final IEventBus modEventBus = context.getModEventBus();
-//        // Forge-provided datapack registries
-//        modEventBus.addListener((DataPackRegistryEvent.NewRegistry event) -> {
-//            event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
-//            event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
-//        });
-//        modEventBus.addListener(this::preInit);
-//        modEventBus.addListener(this::gatherData);
-//        modEventBus.addListener(this::registerFluids);
-//        modEventBus.addListener(this::registerVanillaDisplayContexts);
-//        modEventBus.addListener(this::onRegisterAttributes);
-//        ForgeDeferredRegistriesSetup.setup(modEventBus);
-//        for (var reg : registries)
-//            reg.register(modEventBus);
+        final BusGroup modEventBus = context.getModEventBus();
+        // Forge-provided datapack registries
+        // Hacky code, do not copy!
+        EventBus.create(modEventBus, DataPackRegistryEvent.NewRegistry.class).addListener(event -> {
+            event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
+            event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
+        });
+        synchronized (ForgeMod.class.getClassLoader()) {
+            EventBus.create(modEventBus, FMLCommonSetupEvent.class).addListener(this::preInit);
+            EventBus.create(modEventBus, GatherDataEvent.class).addListener(this::gatherData);
+            EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerFluids);
+            EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerVanillaDisplayContexts);
+            EventBus.create(modEventBus, EntityAttributeModificationEvent.class).addListener(this::onRegisterAttributes);
+        }
+        ForgeDeferredRegistriesSetup.setup(modEventBus);
+        for (var reg : registries)
+            reg.register(modEventBus);
 
         context.registerConfig(ModConfig.Type.CLIENT, ForgeConfig.clientSpec);
         context.registerConfig(ModConfig.Type.SERVER, ForgeConfig.serverSpec);
         context.registerConfig(ModConfig.Type.COMMON, ForgeConfig.commonSpec);
-//        modEventBus.register(ForgeConfig.class);
+        modEventBus.register(MethodHandles.lookup(), ForgeConfig.class);
 
         // Forge does not display problems when the remote is not matching.
         context.registerDisplayTest(IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -393,13 +393,11 @@ public class ForgeMod {
             event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
             event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
         });
-        synchronized (ForgeMod.class.getClassLoader()) {
-            EventBus.create(modEventBus, FMLCommonSetupEvent.class).addListener(this::preInit);
-            EventBus.create(modEventBus, GatherDataEvent.class).addListener(this::gatherData);
-            EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerFluids);
-            EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerVanillaDisplayContexts);
-            EventBus.create(modEventBus, EntityAttributeModificationEvent.class).addListener(this::onRegisterAttributes);
-        }
+        EventBus.create(modEventBus, FMLCommonSetupEvent.class).addListener(this::preInit);
+        EventBus.create(modEventBus, GatherDataEvent.class).addListener(this::gatherData);
+        EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerFluids);
+        EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerVanillaDisplayContexts);
+        EventBus.create(modEventBus, EntityAttributeModificationEvent.class).addListener(this::onRegisterAttributes);
         ForgeDeferredRegistriesSetup.setup(modEventBus);
         for (var reg : registries)
             reg.register(modEventBus);

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -386,26 +386,27 @@ public class ForgeMod {
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 
         // Todo: [Forge][ForgeMod] mod bus registrations
-        final BusGroup modEventBus = context.getModEventBus();
+        final BusGroup modBusGroup = context.getModEventBus();
         // Forge-provided datapack registries
         // Hacky code, do not copy!
-        EventBus.create(modEventBus, DataPackRegistryEvent.NewRegistry.class).addListener(event -> {
+        DataPackRegistryEvent.NewRegistry.getBus(modBusGroup).addListener(event -> {
             event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
             event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
         });
-        EventBus.create(modEventBus, FMLCommonSetupEvent.class).addListener(this::preInit);
-        EventBus.create(modEventBus, GatherDataEvent.class).addListener(this::gatherData);
-        EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerFluids);
-        EventBus.create(modEventBus, RegisterEvent.class).addListener(this::registerVanillaDisplayContexts);
-        EventBus.create(modEventBus, EntityAttributeModificationEvent.class).addListener(this::onRegisterAttributes);
-        ForgeDeferredRegistriesSetup.setup(modEventBus);
+        FMLCommonSetupEvent.getBus(modBusGroup).addListener(this::preInit);
+        GatherDataEvent.getBus(modBusGroup).addListener(this::gatherData);
+        RegisterEvent.getBus(modBusGroup).addListener(this::registerFluids);
+        RegisterEvent.getBus(modBusGroup).addListener(this::registerVanillaDisplayContexts);
+        EntityAttributeModificationEvent.getBus(modBusGroup).addListener(this::onRegisterAttributes);
+
+        ForgeDeferredRegistriesSetup.setup(modBusGroup);
         for (var reg : registries)
-            reg.register(modEventBus);
+            reg.register(modBusGroup);
 
         context.registerConfig(ModConfig.Type.CLIENT, ForgeConfig.clientSpec);
         context.registerConfig(ModConfig.Type.SERVER, ForgeConfig.serverSpec);
         context.registerConfig(ModConfig.Type.COMMON, ForgeConfig.commonSpec);
-        modEventBus.register(MethodHandles.lookup(), ForgeConfig.class);
+        modBusGroup.register(MethodHandles.lookup(), ForgeConfig.class);
 
         // Forge does not display problems when the remote is not matching.
         context.registerDisplayTest(IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -61,8 +61,9 @@ import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveSpawnsBiomeModi
 import net.minecraftforge.common.world.NoneBiomeModifier;
 import net.minecraftforge.common.world.NoneStructureModifier;
 import net.minecraftforge.common.world.StructureModifier;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.event.network.GatherLoginConfigurationTasksEvent;
+import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.*;
@@ -381,33 +382,34 @@ public class ForgeMod {
         CrashReportCallables.registerCrashCallable("FML", ForgeVersion::getSpec);
         CrashReportCallables.registerCrashCallable("Forge", ()->ForgeVersion.getGroup()+":"+ForgeVersion.getVersion());
 
-        final IEventBus modEventBus = context.getModEventBus();
-        // Forge-provided datapack registries
-        modEventBus.addListener((DataPackRegistryEvent.NewRegistry event) -> {
-            event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
-            event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
-        });
-        modEventBus.addListener(this::preInit);
-        modEventBus.addListener(this::gatherData);
-        modEventBus.addListener(this::registerFluids);
-        modEventBus.addListener(this::registerVanillaDisplayContexts);
-        modEventBus.addListener(this::onRegisterAttributes);
-        ForgeDeferredRegistriesSetup.setup(modEventBus);
-        for (var reg : registries)
-            reg.register(modEventBus);
+        // Todo: [Forge][ForgeMod] mod bus registrations
+//        final IEventBus modEventBus = context.getModEventBus();
+//        // Forge-provided datapack registries
+//        modEventBus.addListener((DataPackRegistryEvent.NewRegistry event) -> {
+//            event.dataPackRegistry(ForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
+//            event.dataPackRegistry(ForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
+//        });
+//        modEventBus.addListener(this::preInit);
+//        modEventBus.addListener(this::gatherData);
+//        modEventBus.addListener(this::registerFluids);
+//        modEventBus.addListener(this::registerVanillaDisplayContexts);
+//        modEventBus.addListener(this::onRegisterAttributes);
+//        ForgeDeferredRegistriesSetup.setup(modEventBus);
+//        for (var reg : registries)
+//            reg.register(modEventBus);
 
         context.registerConfig(ModConfig.Type.CLIENT, ForgeConfig.clientSpec);
         context.registerConfig(ModConfig.Type.SERVER, ForgeConfig.serverSpec);
         context.registerConfig(ModConfig.Type.COMMON, ForgeConfig.commonSpec);
-        modEventBus.register(ForgeConfig.class);
+//        modEventBus.register(ForgeConfig.class);
 
         // Forge does not display problems when the remote is not matching.
         context.registerDisplayTest(IExtensionPoint.DisplayTest.IGNORE_ALL_VERSION);
         StartupMessageManager.addModMessage("Forge version "+ForgeVersion.getVersion());
 
-        MinecraftForge.EVENT_BUS.addListener(VillagerTradingManager::loadTrades);
-        MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
-        MinecraftForge.EVENT_BUS.register(new ForgeNetworkConfigurationHandler());
+        ServerAboutToStartEvent.BUS.addListener(VillagerTradingManager::loadTrades);
+        MinecraftForge.INTERNAL_HANDLER.register();
+        GatherLoginConfigurationTasksEvent.BUS.addListener(ForgeNetworkConfigurationHandler::gatherInit);
 
         ForgeRegistries.ITEMS.tags().addOptionalTagDefaults(Tags.Items.ENCHANTING_FUELS, Set.of(ForgeRegistries.ITEMS.getDelegateOrThrow(Items.LAPIS_LAZULI)));
 

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -10,8 +10,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.ConfigScreenHandler;
-import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.IConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
@@ -28,13 +27,15 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class MinecraftForge {
+    // Todo: [Forge] Change javadoc to have migration advice
     /**
      * The EventBus for all the Forge Events.
      *
      * Events marked with {@link net.minecraftforge.fml.event.IModBusEvent}
      * belong on the ModBus and not this bus
      */
-    public static final IEventBus EVENT_BUS = BusBuilder.builder().startShutdown().useModLauncher().build();
+    @Deprecated(forRemoval = true, since = "1.21.5")
+    public static final BusGroup EVENT_BUS = BusGroup.DEFAULT;// BusBuilder.builder().startShutdown().useModLauncher().build();
 
     static final ForgeInternalHandler INTERNAL_HANDLER = new ForgeInternalHandler();
     private static final Logger LOGGER = LogManager.getLogger();

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -10,7 +10,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.ConfigScreenHandler;
-import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.IConfigSpec;

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.ConfigScreenHandler;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.IConfigSpec;

--- a/src/main/java/net/minecraftforge/common/TagConventionMigrationHelper.java
+++ b/src/main/java/net/minecraftforge/common/TagConventionMigrationHelper.java
@@ -28,7 +28,7 @@ public final class TagConventionMigrationHelper {
     private static final ArrayList<TagKey<?>> FOUND_LEGACY_TAGS = new ArrayList<>();
 
     static void init() {
-        MinecraftForge.EVENT_BUS.addListener(TagConventionMigrationHelper::onServerStarting);
+        ServerStartingEvent.BUS.addListener(TagConventionMigrationHelper::onServerStarting);
     }
 
     public static void onServerStarting(ServerStartingEvent event) {

--- a/src/main/java/net/minecraftforge/common/VillagerTradingManager.java
+++ b/src/main/java/net/minecraftforge/common/VillagerTradingManager.java
@@ -54,7 +54,7 @@ public class VillagerTradingManager
         List<ItemListing> rare = NonNullList.create();
         Arrays.stream(WANDERER_TRADES.get(1)).forEach(generic::add);
         Arrays.stream(WANDERER_TRADES.get(2)).forEach(rare::add);
-        MinecraftForge.EVENT_BUS.post(new WandererTradesEvent(generic, rare));
+        WandererTradesEvent.BUS.post(new WandererTradesEvent(generic, rare));
         VillagerTrades.WANDERING_TRADER_TRADES.put(1, generic.toArray(new ItemListing[0]));
         VillagerTrades.WANDERING_TRADER_TRADES.put(2, rare.toArray(new ItemListing[0]));
     }
@@ -75,7 +75,7 @@ public class VillagerTradingManager
             for (var entry : trades.int2ObjectEntrySet()) {
                 Arrays.stream(entry.getValue()).forEach(mutableTrades.get(entry.getIntKey())::add);
             }
-            MinecraftForge.EVENT_BUS.post(new VillagerTradesEvent(mutableTrades, prof));
+            VillagerTradesEvent.BUS.post(new VillagerTradesEvent(mutableTrades, prof));
             Int2ObjectMap<ItemListing[]> newTrades = new Int2ObjectOpenHashMap<>();
             for (var entry : mutableTrades.int2ObjectEntrySet()) {
                 newTrades.put(entry.getIntKey(), entry.getValue().toArray(new ItemListing[0]));

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -11,9 +11,12 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -23,10 +26,14 @@ import java.util.function.Supplier;
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> implements ICapabilityProviderImpl<B> {
+
+    public interface CapabilitySupplier<B> {
+        AttachCapabilitiesEvent<B> create(B provider);
+    }
+
     @VisibleForTesting
     static boolean SUPPORTS_LAZY_CAPABILITIES = true;
 
-    private final @NotNull Class<B> baseClass;
     private @Nullable CapabilityDispatcher capabilities;
     private boolean valid = true;
 
@@ -36,12 +43,11 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
     private HolderLookup.Provider         registryAccess     = null;
     private boolean initialized = false;
 
-    protected CapabilityProvider(Class<B> baseClass) {
-        this(baseClass, false);
+    protected CapabilityProvider() {
+        this(false);
     }
 
-    protected CapabilityProvider(final Class<B> baseClass, final boolean isLazy) {
-        this.baseClass = baseClass;
+    protected CapabilityProvider(final boolean isLazy) {
         this.isLazy = SUPPORTS_LAZY_CAPABILITIES && isLazy;
     }
 
@@ -63,9 +69,12 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
     }
 
     private void doGatherCapabilities(@Nullable ICapabilityProvider parent) {
-        this.capabilities = ForgeEventFactory.gatherCapabilities(baseClass, getProvider(), parent);
+        var event = postEvent(getProvider());
+        this.capabilities = !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
         this.initialized = true;
     }
+
+    protected abstract AttachCapabilitiesEvent<?> postEvent(B provider);
 
     @SuppressWarnings("unchecked")
     @NotNull
@@ -146,14 +155,16 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
      */
     public static class AsField<B extends ICapabilityProviderImpl<B>> extends CapabilityProvider<B> {
         private final B owner;
+        private final CapabilitySupplier<B> supplier;
 
-        public AsField(Class<B> baseClass, B owner) {
-            super(baseClass);
+        public AsField(final CapabilitySupplier<B> eventSupplier, B owner) {
+            this.supplier = eventSupplier;
             this.owner = owner;
         }
 
-        public AsField(Class<B> baseClass, B owner, boolean isLazy) {
-            super(baseClass, isLazy);
+        public AsField(final CapabilitySupplier<B> eventSupplier, B owner, boolean isLazy) {
+            super(isLazy);
+            this.supplier = eventSupplier;
             this.owner = owner;
         }
 
@@ -168,6 +179,11 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
 
         public void deserializeInternal(HolderLookup.Provider registryAccess, CompoundTag tag) {
             deserializeCaps(registryAccess, tag);
+        }
+
+        @Override
+        protected AttachCapabilitiesEvent<?> postEvent(B provider) {
+            return supplier.create(provider);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -11,12 +11,9 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -26,14 +23,10 @@ import java.util.function.Supplier;
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> implements ICapabilityProviderImpl<B> {
-
-    public interface CapabilitySupplier<B> {
-        AttachCapabilitiesEvent<B> create(B provider);
-    }
-
     @VisibleForTesting
     static boolean SUPPORTS_LAZY_CAPABILITIES = true;
 
+    private final @NotNull Class<B> baseClass;
     private @Nullable CapabilityDispatcher capabilities;
     private boolean valid = true;
 
@@ -43,11 +36,12 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
     private HolderLookup.Provider         registryAccess     = null;
     private boolean initialized = false;
 
-    protected CapabilityProvider() {
-        this(false);
+    protected CapabilityProvider(Class<B> baseClass) {
+        this(baseClass, false);
     }
 
-    protected CapabilityProvider(final boolean isLazy) {
+    protected CapabilityProvider(final Class<B> baseClass, final boolean isLazy) {
+        this.baseClass = baseClass;
         this.isLazy = SUPPORTS_LAZY_CAPABILITIES && isLazy;
     }
 
@@ -69,12 +63,9 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
     }
 
     private void doGatherCapabilities(@Nullable ICapabilityProvider parent) {
-        var event = postEvent(getProvider());
-        this.capabilities = !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
+        this.capabilities = ForgeEventFactory.gatherCapabilities(baseClass, getProvider(), parent);
         this.initialized = true;
     }
-
-    protected abstract AttachCapabilitiesEvent<?> postEvent(B provider);
 
     @SuppressWarnings("unchecked")
     @NotNull
@@ -155,16 +146,14 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
      */
     public static class AsField<B extends ICapabilityProviderImpl<B>> extends CapabilityProvider<B> {
         private final B owner;
-        private final CapabilitySupplier<B> supplier;
 
-        public AsField(final CapabilitySupplier<B> eventSupplier, B owner) {
-            this.supplier = eventSupplier;
+        public AsField(Class<B> baseClass, B owner) {
+            super(baseClass);
             this.owner = owner;
         }
 
-        public AsField(final CapabilitySupplier<B> eventSupplier, B owner, boolean isLazy) {
-            super(isLazy);
-            this.supplier = eventSupplier;
+        public AsField(Class<B> baseClass, B owner, boolean isLazy) {
+            super(baseClass, isLazy);
             this.owner = owner;
         }
 
@@ -179,11 +168,6 @@ public abstract class CapabilityProvider<B extends ICapabilityProviderImpl<B>> i
 
         public void deserializeInternal(HolderLookup.Provider registryAccess, CompoundTag tag) {
             deserializeCaps(registryAccess, tag);
-        }
-
-        @Override
-        protected AttachCapabilitiesEvent<?> postEvent(B provider) {
-            return supplier.create(provider);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -7,9 +7,9 @@ package net.minecraftforge.common.capabilities;
 
 import java.util.Objects;
 
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.objectweb.asm.Type;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
@@ -19,7 +19,9 @@ import net.minecraftforge.fml.event.IModBusEvent;
  * @deprecated Use {@link AutoRegisterCapability} annotation on your class.
  */
 @Deprecated(forRemoval = true, since = "1.21")
-public final class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
+public final class RegisterCapabilitiesEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     /**
      * Registers a capability to be consumed by others.
      * APIs who define the capability should call this.

--- a/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/RegisterCapabilitiesEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.common.capabilities;
 
 import java.util.Objects;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.objectweb.asm.Type;
 
@@ -20,7 +22,9 @@ import net.minecraftforge.fml.event.IModBusEvent;
  */
 @Deprecated(forRemoval = true, since = "1.21")
 public final class RegisterCapabilitiesEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterCapabilitiesEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterCapabilitiesEvent.class);
+    }
 
     /**
      * Registers a capability to be consumed by others.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeGameTestHelper.java
@@ -41,8 +41,6 @@ import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.ForgeI18n;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
 
 public interface IForgeGameTestHelper {
     private GameTestHelper self() {
@@ -150,20 +148,29 @@ public interface IForgeGameTestHelper {
         return player;
     }
 
-    /**
-     * Registers an event listener that will be unregistered when the test is finished running.
-     */
-    default <E extends Event> void addEventListener(Consumer<E> consumer) {
-        MinecraftForge.EVENT_BUS.addListener(consumer);
-        self().addCleanup(success -> MinecraftForge.EVENT_BUS.unregister(consumer));
+    // Todo: [Forge][GameTest] add/remove event listener methods need migrating to EventBus v7
+//    /**
+//     * Registers an event listener that will be unregistered when the test is finished running.
+//     */
+//    default <E extends Event> void addEventListener(Consumer<E> consumer) {
+//        MinecraftForge.EVENT_BUS.addListener(consumer);
+//        self().addCleanup(success -> MinecraftForge.EVENT_BUS.unregister(consumer));
+//    }
+//
+//    /**
+//     * Registers an event listener that will be unregistered when the test is finished running.
+//     */
+//    default void registerEventListener(Object handler) {
+//        MinecraftForge.EVENT_BUS.register(handler);
+//        self().addCleanup(success -> MinecraftForge.EVENT_BUS.unregister(handler));
+//    }
+
+    default void addEventListener(Consumer<?> consumer) {
+        throw new RuntimeException("Todo: [Forge][GameTest] addEventListener(Consumer<?>) method needs migrating to EventBus v7");
     }
 
-    /**
-     * Registers an event listener that will be unregistered when the test is finished running.
-     */
     default void registerEventListener(Object handler) {
-        MinecraftForge.EVENT_BUS.register(handler);
-        self().addCleanup(success -> MinecraftForge.EVENT_BUS.unregister(handler));
+        throw new RuntimeException("Todo: [Forge][GameTest] registerEventListener(Object) method needs migrating to EventBus v7");
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/util/CancellableAware.java
+++ b/src/main/java/net/minecraftforge/common/util/CancellableAware.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.common.util;
+
+// Temporary solution for events that rely on the cancellation state being stored inside the event object
+public interface CancellableAware {
+    default boolean isCanceled() {
+        return false;
+    }
+
+    default void setCanceled(boolean cancelled) {}
+}

--- a/src/main/java/net/minecraftforge/common/util/HasResult.java
+++ b/src/main/java/net/minecraftforge/common/util/HasResult.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.common.util;
+
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+
+public interface HasResult {
+    Result getResult();
+    void setResult(Result result);
+
+    /**
+     * A version of {@link HasResult} tailored for {@link RecordEvent}s.
+     */
+    interface Record extends HasResult {
+        Result.Holder resultHolder();
+
+        default Result getResult() {
+            return resultHolder().get();
+        }
+
+        default void setResult(Result result) {
+            resultHolder().set(result);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/util/Result.java
+++ b/src/main/java/net/minecraftforge/common/util/Result.java
@@ -1,0 +1,62 @@
+package net.minecraftforge.common.util;
+
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+
+import java.util.Objects;
+
+public enum Result {
+    ALLOW,
+    DEFAULT,
+    DENY;
+
+    public boolean isAllowed() {
+        return this == ALLOW;
+    }
+
+    public boolean isDefault() {
+        return this == DEFAULT;
+    }
+
+    public boolean isDenied() {
+        return this == DENY;
+    }
+
+    /**
+     * A mutable holder for a Result, useful for {@link RecordEvent}s combined with {@link HasResult.Record}
+     */
+    public static final class Holder {
+        private Result value;
+
+        public Holder() {
+            set(DEFAULT);
+        }
+
+        public Holder(Result value) {
+            set(value);
+        }
+
+        public Result get() {
+            return value;
+        }
+
+        public void set(Result value) {
+            Objects.requireNonNull(value);
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "Result.Holder{value=" + value + "\"}";
+        }
+
+        @Override
+        public boolean equals(Object that) {
+            return this == that || (that instanceof Holder thatHolder && this.value == thatHolder.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
@@ -10,7 +10,7 @@ import net.minecraft.DetectedVersion;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.DataGenerator;
 import net.minecraftforge.common.data.ExistingFileHelper;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.event.IModBusEvent;
 
@@ -25,8 +25,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class GatherDataEvent extends Event implements IModBusEvent
-{
+public class GatherDataEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final DataGenerator dataGenerator;
     private final DataGeneratorConfig config;
     private final ExistingFileHelper existingFileHelper;

--- a/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/data/event/GatherDataEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.DetectedVersion;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.DataGenerator;
 import net.minecraftforge.common.data.ExistingFileHelper;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -26,7 +28,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class GatherDataEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<GatherDataEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, GatherDataEvent.class);
+    }
 
     private final DataGenerator dataGenerator;
     private final DataGeneratorConfig config;

--- a/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.event;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.packs.repository.RepositorySource;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 
 import java.util.function.Consumer;
@@ -16,7 +16,8 @@ import java.util.function.Consumer;
 /**
  * Fired on {@link PackRepository} creation to allow mods to add new pack finders.
  */
-public class AddPackFindersEvent extends Event implements IModBusEvent {
+public class AddPackFindersEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] AddPackFindersEvent.BUS from mod BusGroup
     private final PackType packType;
     private final Consumer<RepositorySource> sources;
 

--- a/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddPackFindersEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.event;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.packs.repository.RepositorySource;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 
@@ -17,7 +19,10 @@ import java.util.function.Consumer;
  * Fired on {@link PackRepository} creation to allow mods to add new pack finders.
  */
 public class AddPackFindersEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] AddPackFindersEvent.BUS from mod BusGroup
+    public static EventBus<AddPackFindersEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, AddPackFindersEvent.class);
+    }
+
     private final PackType packType;
     private final Consumer<RepositorySource> sources;
 

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -7,15 +7,14 @@ package net.minecraftforge.event;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.LayeredRegistryAccess;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.server.RegistryLayer;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.conditions.ICondition;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.ModLoader;
 
 import java.util.ArrayList;
@@ -29,7 +28,9 @@ import java.util.concurrent.Executor;
  * The event is fired on each reload and lets modders add their own ReloadListeners, for server-side resources.
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}
  */
-public class AddReloadListenerEvent extends Event {
+public class AddReloadListenerEvent extends MutableEvent {
+    public static final EventBus<AddReloadListenerEvent> BUS = EventBus.create(AddReloadListenerEvent.class);
+
     private final List<PreparableReloadListener> listeners = new ArrayList<>();
     private final ReloadableServerResources serverResources;
 

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -8,8 +8,9 @@ package net.minecraftforge.event;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -20,8 +21,9 @@ import org.jetbrains.annotations.Nullable;
  * If the event is not canceled, but the output is not empty, it will set the output and not run vanilla behavior. <br>
  * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
  */
-@Cancelable
-public class AnvilUpdateEvent extends Event {
+public class AnvilUpdateEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<AnvilUpdateEvent> BUS = CancancellableEventBus.create(AnvilUpdateEvent.class);
+
     private final ItemStack left;
     private final ItemStack right;
     private final String name;

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
  * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
  */
 public class AnvilUpdateEvent extends MutableEvent implements Cancellable {
-    public static final CancellableEventBus<AnvilUpdateEvent> BUS = CancancellableEventBus.create(AnvilUpdateEvent.class);
+    public static final CancellableEventBus<AnvilUpdateEvent> BUS = CancellableEventBus.create(AnvilUpdateEvent.class);
 
     private final ItemStack left;
     private final ItemStack right;

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -6,12 +6,19 @@
 package net.minecraftforge.event;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
@@ -21,7 +28,66 @@ import net.minecraftforge.eventbus.api.event.MutableEvent;
  * Please note that as this is fired for ALL object creations efficient code is recommended.
  * And if possible use one of the sub-classes to filter your intended objects.
  */
-public class AttachCapabilitiesEvent<T> extends MutableEvent {
+public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
+
+    public interface Factory<T> {
+        AttachCapabilitiesEvent<T> create(T obj);
+    }
+
+    private static final Map<Class<?>, Factory<?>> factoryMap = new HashMap<>();
+
+    private static <T> void register(Class<T> tClass, Factory<T> factory) {
+        factoryMap.put(tClass, factory);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> AttachCapabilitiesEvent<T> create(Class<? extends T> tClass, T provider) {
+        return ((Factory<T>) factoryMap.get(tClass)).create(provider);
+    }
+
+    static {
+        register(Entity.class, EntityEvent::new);
+        register(BlockEntity.class, BlockEntityEvent::new);
+        register(ItemStack.class, ItemStackEvent::new);
+        register(Level.class, LevelEvent::new);
+        register(LevelChunk.class, LevelChunkEvent::new);
+    }
+
+    public static final class EntityEvent extends AttachCapabilitiesEvent<Entity> {
+        public static final EventBus<EntityEvent> BUS = EventBus.create(EntityEvent.class);
+        public EntityEvent(Entity obj) {
+            super(obj);
+        }
+    }
+
+    public static final class BlockEntityEvent extends AttachCapabilitiesEvent<BlockEntity> {
+        public static final EventBus<BlockEntityEvent> BUS = EventBus.create(BlockEntityEvent.class);
+        public BlockEntityEvent(BlockEntity obj) {
+            super(obj);
+        }
+    }
+
+    public static final class ItemStackEvent extends AttachCapabilitiesEvent<ItemStack> {
+        public static final EventBus<ItemStackEvent> BUS = EventBus.create(ItemStackEvent.class);
+        public ItemStackEvent(ItemStack obj) {
+            super(obj);
+        }
+    }
+
+    public static final class LevelEvent extends AttachCapabilitiesEvent<Level> {
+        public static final EventBus<LevelEvent> BUS = EventBus.create(LevelEvent.class);
+        public LevelEvent(Level obj) {
+            super(obj);
+        }
+    }
+
+    public static final class LevelChunkEvent extends AttachCapabilitiesEvent<LevelChunk> {
+        public static final EventBus<LevelChunkEvent> BUS = EventBus.create(LevelChunkEvent.class);
+        public LevelChunkEvent(LevelChunk obj) {
+            super(obj);
+        }
+    }
+
     // Todo: [Forge][Event] Make this play nice with EventBus v7
 
     private final T obj;
@@ -30,9 +96,8 @@ public class AttachCapabilitiesEvent<T> extends MutableEvent {
     private final List<Runnable> listeners = Lists.newArrayList();
     private final List<Runnable> listenersView = Collections.unmodifiableList(listeners);
 
-    public AttachCapabilitiesEvent(Class<T> type, T obj)
+    public AttachCapabilitiesEvent(T obj)
     {
-        //super(type);
         this.obj = obj;
     }
 

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -60,7 +60,7 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<EntityEvent> BUS = EventBus.create(EntityEvent.class);
 
         @ApiStatus.Internal
-        EntityEvent(Entity obj) {
+        public EntityEvent(Entity obj) {
             super(obj);
         }
 
@@ -74,7 +74,7 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<BlockEntityEvent> BUS = EventBus.create(BlockEntityEvent.class);
 
         @ApiStatus.Internal
-        BlockEntityEvent(BlockEntity obj) {
+        public BlockEntityEvent(BlockEntity obj) {
             super(obj);
         }
 
@@ -88,7 +88,7 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<ItemStackEvent> BUS = EventBus.create(ItemStackEvent.class);
 
         @ApiStatus.Internal
-        ItemStackEvent(ItemStack obj) {
+        public ItemStackEvent(ItemStack obj) {
             super(obj);
         }
 
@@ -102,7 +102,7 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<LevelEvent> BUS = EventBus.create(LevelEvent.class);
 
         @ApiStatus.Internal
-        LevelEvent(Level obj) {
+        public LevelEvent(Level obj) {
             super(obj);
         }
 
@@ -116,7 +116,7 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<LevelChunkEvent> BUS = EventBus.create(LevelChunkEvent.class);
 
         @ApiStatus.Internal
-        LevelChunkEvent(LevelChunk obj) {
+        public LevelChunkEvent(LevelChunk obj) {
             super(obj);
         }
 

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.eventbus.api.GenericEvent;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * Fired whenever an object with Capabilities support {currently TileEntity/Item/Entity)
@@ -21,8 +21,9 @@ import net.minecraftforge.eventbus.api.GenericEvent;
  * Please note that as this is fired for ALL object creations efficient code is recommended.
  * And if possible use one of the sub-classes to filter your intended objects.
  */
-public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
-{
+public class AttachCapabilitiesEvent<T> extends MutableEvent {
+    // Todo: [Forge][Event] Make this play nice with EventBus v7
+
     private final T obj;
     private final Map<ResourceLocation, ICapabilityProvider> caps = Maps.newLinkedHashMap();
     private final Map<ResourceLocation, ICapabilityProvider> view = Collections.unmodifiableMap(caps);

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -33,40 +33,12 @@ import org.jetbrains.annotations.ApiStatus;
  */
 public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
 
-    interface Factory<T> {
-        AttachCapabilitiesEvent<T> create(T obj);
-    }
-
-    private static final Map<Class<?>, Factory<?>> factoryMap = new HashMap<>();
-
-    private static <T> void register(Class<T> tClass, Factory<T> factory) {
-        factoryMap.put(tClass, factory);
-    }
-
-    @SuppressWarnings("unchecked")
-    static <T> AttachCapabilitiesEvent<T> create(Class<? extends T> tClass, T provider) {
-        return ((Factory<T>) factoryMap.get(tClass)).create(provider);
-    }
-
-    static {
-        register(Entity.class, EntityEvent::new);
-        register(BlockEntity.class, BlockEntityEvent::new);
-        register(ItemStack.class, ItemStackEvent::new);
-        register(Level.class, LevelEvent::new);
-        register(LevelChunk.class, LevelChunkEvent::new);
-    }
-
     public static final class EntityEvent extends AttachCapabilitiesEvent<Entity> {
         public static final EventBus<EntityEvent> BUS = EventBus.create(EntityEvent.class);
 
         @ApiStatus.Internal
-        EntityEvent(Entity obj) {
+        public EntityEvent(Entity obj) {
             super(obj);
-        }
-
-        @Override
-        void post() {
-            BUS.post(this);
         }
     }
 
@@ -74,13 +46,8 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<BlockEntityEvent> BUS = EventBus.create(BlockEntityEvent.class);
 
         @ApiStatus.Internal
-        BlockEntityEvent(BlockEntity obj) {
+        public BlockEntityEvent(BlockEntity obj) {
             super(obj);
-        }
-
-        @Override
-        void post() {
-            BUS.post(this);
         }
     }
 
@@ -88,13 +55,8 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<ItemStackEvent> BUS = EventBus.create(ItemStackEvent.class);
 
         @ApiStatus.Internal
-        ItemStackEvent(ItemStack obj) {
+        public ItemStackEvent(ItemStack obj) {
             super(obj);
-        }
-
-        @Override
-        void post() {
-            BUS.post(this);
         }
     }
 
@@ -102,13 +64,8 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<LevelEvent> BUS = EventBus.create(LevelEvent.class);
 
         @ApiStatus.Internal
-        LevelEvent(Level obj) {
+        public LevelEvent(Level obj) {
             super(obj);
-        }
-
-        @Override
-        void post() {
-            BUS.post(this);
         }
     }
 
@@ -116,13 +73,8 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<LevelChunkEvent> BUS = EventBus.create(LevelChunkEvent.class);
 
         @ApiStatus.Internal
-        LevelChunkEvent(LevelChunk obj) {
+        public LevelChunkEvent(LevelChunk obj) {
             super(obj);
-        }
-
-        @Override
-        void post() {
-            BUS.post(this);
         }
     }
 
@@ -184,6 +136,4 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
     {
         return this.listenersView;
     }
-
-    abstract void post();
 }

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -32,7 +32,7 @@ public class AttachCapabilitiesEvent<T> extends MutableEvent {
 
     public AttachCapabilitiesEvent(Class<T> type, T obj)
     {
-        super(type);
+        //super(type);
         this.obj = obj;
     }
 

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -20,6 +20,9 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfPosting;
+import net.minecraftforge.eventbus.internal.Event;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired whenever an object with Capabilities support {currently TileEntity/Item/Entity)
@@ -30,7 +33,7 @@ import net.minecraftforge.eventbus.api.event.MutableEvent;
  */
 public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
 
-    public interface Factory<T> {
+    interface Factory<T> {
         AttachCapabilitiesEvent<T> create(T obj);
     }
 
@@ -41,7 +44,7 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> AttachCapabilitiesEvent<T> create(Class<? extends T> tClass, T provider) {
+    static <T> AttachCapabilitiesEvent<T> create(Class<? extends T> tClass, T provider) {
         return ((Factory<T>) factoryMap.get(tClass)).create(provider);
     }
 
@@ -55,36 +58,71 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
 
     public static final class EntityEvent extends AttachCapabilitiesEvent<Entity> {
         public static final EventBus<EntityEvent> BUS = EventBus.create(EntityEvent.class);
-        public EntityEvent(Entity obj) {
+
+        @ApiStatus.Internal
+        EntityEvent(Entity obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
     public static final class BlockEntityEvent extends AttachCapabilitiesEvent<BlockEntity> {
         public static final EventBus<BlockEntityEvent> BUS = EventBus.create(BlockEntityEvent.class);
-        public BlockEntityEvent(BlockEntity obj) {
+
+        @ApiStatus.Internal
+        BlockEntityEvent(BlockEntity obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
     public static final class ItemStackEvent extends AttachCapabilitiesEvent<ItemStack> {
         public static final EventBus<ItemStackEvent> BUS = EventBus.create(ItemStackEvent.class);
-        public ItemStackEvent(ItemStack obj) {
+
+        @ApiStatus.Internal
+        ItemStackEvent(ItemStack obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
     public static final class LevelEvent extends AttachCapabilitiesEvent<Level> {
         public static final EventBus<LevelEvent> BUS = EventBus.create(LevelEvent.class);
-        public LevelEvent(Level obj) {
+
+        @ApiStatus.Internal
+        LevelEvent(Level obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
     public static final class LevelChunkEvent extends AttachCapabilitiesEvent<LevelChunk> {
         public static final EventBus<LevelChunkEvent> BUS = EventBus.create(LevelChunkEvent.class);
-        public LevelChunkEvent(LevelChunk obj) {
+
+        @ApiStatus.Internal
+        LevelChunkEvent(LevelChunk obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
@@ -146,4 +184,6 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
     {
         return this.listenersView;
     }
+
+    abstract void post();
 }

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -33,12 +33,40 @@ import org.jetbrains.annotations.ApiStatus;
  */
 public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
 
+    interface Factory<T> {
+        AttachCapabilitiesEvent<T> create(T obj);
+    }
+
+    private static final Map<Class<?>, Factory<?>> factoryMap = new HashMap<>();
+
+    private static <T> void register(Class<T> tClass, Factory<T> factory) {
+        factoryMap.put(tClass, factory);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> AttachCapabilitiesEvent<T> create(Class<? extends T> tClass, T provider) {
+        return ((Factory<T>) factoryMap.get(tClass)).create(provider);
+    }
+
+    static {
+        register(Entity.class, EntityEvent::new);
+        register(BlockEntity.class, BlockEntityEvent::new);
+        register(ItemStack.class, ItemStackEvent::new);
+        register(Level.class, LevelEvent::new);
+        register(LevelChunk.class, LevelChunkEvent::new);
+    }
+
     public static final class EntityEvent extends AttachCapabilitiesEvent<Entity> {
         public static final EventBus<EntityEvent> BUS = EventBus.create(EntityEvent.class);
 
         @ApiStatus.Internal
-        public EntityEvent(Entity obj) {
+        EntityEvent(Entity obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
@@ -46,8 +74,13 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<BlockEntityEvent> BUS = EventBus.create(BlockEntityEvent.class);
 
         @ApiStatus.Internal
-        public BlockEntityEvent(BlockEntity obj) {
+        BlockEntityEvent(BlockEntity obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
@@ -55,8 +88,13 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<ItemStackEvent> BUS = EventBus.create(ItemStackEvent.class);
 
         @ApiStatus.Internal
-        public ItemStackEvent(ItemStack obj) {
+        ItemStackEvent(ItemStack obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
@@ -64,8 +102,13 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<LevelEvent> BUS = EventBus.create(LevelEvent.class);
 
         @ApiStatus.Internal
-        public LevelEvent(Level obj) {
+        LevelEvent(Level obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
@@ -73,8 +116,13 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
         public static final EventBus<LevelChunkEvent> BUS = EventBus.create(LevelChunkEvent.class);
 
         @ApiStatus.Internal
-        public LevelChunkEvent(LevelChunk obj) {
+        LevelChunkEvent(LevelChunk obj) {
             super(obj);
+        }
+
+        @Override
+        void post() {
+            BUS.post(this);
         }
     }
 
@@ -136,4 +184,6 @@ public sealed abstract class AttachCapabilitiesEvent<T> extends MutableEvent {
     {
         return this.listenersView;
     }
+
+    abstract void post();
 }

--- a/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
@@ -11,6 +11,8 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.common.util.MutableHashedLinkedMap;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -29,7 +31,9 @@ import java.util.function.Supplier;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.
  */
 public final class BuildCreativeModeTabContentsEvent extends MutableEvent implements IModBusEvent, CreativeModeTab.Output {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<BuildCreativeModeTabContentsEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, BuildCreativeModeTabContentsEvent.class);
+    }
 
     private final CreativeModeTab tab;
     private final CreativeModeTab.ItemDisplayParameters parameters;

--- a/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
@@ -11,8 +11,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.common.util.MutableHashedLinkedMap;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -29,7 +28,9 @@ import java.util.function.Supplier;
  * This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.
  */
-public final class BuildCreativeModeTabContentsEvent extends Event implements IModBusEvent, CreativeModeTab.Output {
+public final class BuildCreativeModeTabContentsEvent extends MutableEvent implements IModBusEvent, CreativeModeTab.Output {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final CreativeModeTab tab;
     private final CreativeModeTab.ItemDisplayParameters parameters;
     private final MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility> entries;

--- a/src/main/java/net/minecraftforge/event/CommandEvent.java
+++ b/src/main/java/net/minecraftforge/event/CommandEvent.java
@@ -9,8 +9,9 @@ import com.mojang.brigadier.ParseResults;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,9 +25,9 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-@Cancelable
-public class CommandEvent extends Event
-{
+public class CommandEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<CommandEvent> BUS = CancellableEventBus.create(CommandEvent.class);
+
     private ParseResults<CommandSourceStack> parse;
     @Nullable
     private Throwable exception;

--- a/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.event;
 import net.minecraft.world.Difficulty;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * DifficultyChangeEvent is fired when difficulty is changing. <br>
@@ -19,7 +20,9 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class DifficultyChangeEvent extends Event {
+public class DifficultyChangeEvent extends MutableEvent {
+    public static final EventBus<DifficultyChangeEvent> BUS = EventBus.create(DifficultyChangeEvent.class);
+
     private final Difficulty difficulty;
     private final Difficulty oldDifficulty;
 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
+import net.minecraft.client.renderer.item.properties.conditional.ExtendedView;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.world.entity.*;
@@ -582,8 +583,7 @@ public final class ForgeEventFactory {
 
     @Nullable
     private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent) {
-        // Todo: [Forge][EventFactory] gatherCapabilities event post
-//        post(event);
+        event.post();
         return !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
     }
 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -20,9 +20,7 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
-import net.minecraftforge.common.capabilities.CapabilityProvider;
 import net.minecraftforge.common.util.Result;
-import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
@@ -570,6 +568,23 @@ public final class ForgeEventFactory {
 
     public static void onPlayerBrewedPotion(Player player, ItemStack stack) {
         PlayerBrewedPotionEvent.BUS.post(new PlayerBrewedPotionEvent(player, stack));
+    }
+
+    @Nullable
+    public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider) {
+        return gatherCapabilities(type, provider, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider, @Nullable ICapabilityProvider parent) {
+        return gatherCapabilities(AttachCapabilitiesEvent.create(type, provider), parent);
+    }
+
+    @Nullable
+    private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent) {
+        event.post();
+        return !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
     }
 
     public static boolean fireSleepingLocationCheck(LivingEntity player, BlockPos sleepingLocation) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -577,7 +577,7 @@ public final class ForgeEventFactory {
     @SuppressWarnings("unchecked")
     @Nullable
     public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider, @Nullable ICapabilityProvider parent) {
-        return gatherCapabilities(new AttachCapabilitiesEvent<T>((Class<T>) type, provider), parent);
+        return gatherCapabilities(AttachCapabilitiesEvent.create(type, provider), parent);
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -15,15 +15,11 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.LayeredRegistryAccess;
 import net.minecraft.core.component.DataComponentMap;
-import net.minecraft.server.RegistryLayer;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
@@ -203,7 +199,6 @@ import net.minecraftforge.event.level.SleepFinishedTimeEvent;
 import net.minecraftforge.event.network.ChannelRegistrationChangeEvent;
 import net.minecraftforge.event.network.ConnectionStartEvent;
 import net.minecraftforge.event.network.GatherLoginConfigurationTasksEvent;
-import net.minecraftforge.eventbus.api.Event.Result;
 import net.minecraftforge.fml.LogicalSide;
 
 @ApiStatus.Internal
@@ -213,26 +208,9 @@ public final class ForgeEventFactory {
     private ForgeEventFactory() {}
 
     /**
-     * Post an event to the {@link MinecraftForge#EVENT_BUS}
-     * @return true if the event is {@link Cancelable} and has been canceled
-     */
-    private static boolean post(Event e) {
-        return MinecraftForge.EVENT_BUS.post(e);
-    }
-
-    /**
-     * Post an event to the {@link MinecraftForge#EVENT_BUS}, then return the event object
-     * @return the event object passed in and possibly modified by listeners
-     */
-    private static <E extends Event> E fire(E e) {
-        post(e);
-        return e;
-    }
-
-    /**
      * Post an event to the {@link ModLoader#get()} event bus
      */
-    private static <T extends Event & IModBusEvent> void postModBus(T e) {
+    private static <T extends IModBusEvent> void postModBus(T e) {
         ML.postEvent(e);
     }
 
@@ -240,26 +218,26 @@ public final class ForgeEventFactory {
         var snap = blockSnapshots.get(0);
         var placedAgainst = snap.getLevel().getBlockState(snap.getPos().relative(direction.getOpposite()));
         var event = new EntityMultiPlaceEvent(blockSnapshots, placedAgainst, entity);
-        return post(event);
+        return EntityMultiPlaceEvent.BUS.post(event);
     }
 
     public static boolean onBlockPlace(@Nullable Entity entity, @NotNull BlockSnapshot blockSnapshot, @NotNull Direction direction) {
         var placedAgainst = blockSnapshot.getLevel().getBlockState(blockSnapshot.getPos().relative(direction.getOpposite()));
         var event = new BlockEvent.EntityPlaceEvent(blockSnapshot, placedAgainst, entity);
-        return post(event);
+        return BlockEvent.EntityPlaceEvent.BUS.post(event);
     }
 
     public static boolean onNeighborNotify(Level level, BlockPos pos, BlockState state, EnumSet<Direction> notifiedSides, boolean forceRedstoneUpdate) {
-        return post(new NeighborNotifyEvent(level, pos, state, notifiedSides, forceRedstoneUpdate));
+        return NeighborNotifyEvent.BUS.post(new NeighborNotifyEvent(level, pos, state, notifiedSides, forceRedstoneUpdate));
     }
 
     public static boolean doPlayerHarvestCheck(Player player, BlockState state, boolean success) {
-        return fire(new PlayerEvent.HarvestCheck(player, state, success)).canHarvest();
+        return PlayerEvent.HarvestCheck.BUS.fire(new PlayerEvent.HarvestCheck(player, state, success)).canHarvest();
     }
 
     public static float getBreakSpeed(Player player, BlockState state, float original, BlockPos pos) {
         var event = new PlayerEvent.BreakSpeed(player, state, original, pos);
-        return (post(event) ? -1 : event.getNewSpeed());
+        return (PlayerEvent.BreakSpeed.BUS.post(event) ? -1 : event.getNewSpeed());
     }
 
     public static void onPlayerDestroyItem(Player player, @NotNull ItemStack stack, @Nullable InteractionHand hand) {
@@ -267,11 +245,11 @@ public final class ForgeEventFactory {
     }
 
     public static void onPlayerDestroyItem(Player player, @NotNull ItemStack stack, @Nullable EquipmentSlot slot) {
-        post(new PlayerDestroyItemEvent(player, stack, slot));
+        PlayerDestroyItemEvent.BUS.post(new PlayerDestroyItemEvent(player, stack, slot));
     }
 
     public static boolean checkSpawnPlacements(EntityType<?> entityType, ServerLevelAccessor level, EntitySpawnReason spawnType, BlockPos pos, RandomSource random, boolean defaultResult) {
-        var result = fire(new SpawnPlacementCheck(entityType, level, spawnType, pos, random, defaultResult)).getResult();
+        var result = SpawnPlacementCheck.BUS.fire(new SpawnPlacementCheck(entityType, level, spawnType, pos, random, defaultResult)).getResult();
         return result == Result.DEFAULT ? defaultResult : result == Result.ALLOW;
     }
 
@@ -285,7 +263,7 @@ public final class ForgeEventFactory {
      * @see PositionCheck
      */
     public static boolean checkSpawnPosition(Mob mob, ServerLevelAccessor level, EntitySpawnReason spawnType) {
-        var result = fire(new PositionCheck(mob, level, spawnType, null)).getResult();
+        var result = PositionCheck.BUS.fire(new PositionCheck(mob, level, spawnType, null)).getResult();
         if (result == Result.DEFAULT)
             return mob.checkSpawnRules(level, spawnType) && mob.checkSpawnObstruction(level);
         return result == Result.ALLOW;
@@ -297,7 +275,7 @@ public final class ForgeEventFactory {
      * @implNote See in-line comments about custom spawn rules.
      */
     public static boolean checkSpawnPositionSpawner(Mob mob, ServerLevelAccessor level, EntitySpawnReason spawnType, SpawnData spawnData, BaseSpawner spawner) {
-        var result = fire(new PositionCheck(mob, level, spawnType, null)).getResult();
+        var result = PositionCheck.BUS.fire(new PositionCheck(mob, level, spawnType, null)).getResult();
         if (result == Result.DEFAULT) {
             // Spawners do not evaluate Mob#checkSpawnRules if any custom rules are present. This is despite the fact that these two methods do not check the same things.
             return (spawnData.getCustomSpawnRules().isPresent() || mob.checkSpawnRules(level, spawnType)) && mob.checkSpawnObstruction(level);
@@ -339,7 +317,7 @@ public final class ForgeEventFactory {
     @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
     public static SpawnGroupData onFinalizeSpawn(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, EntitySpawnReason spawnType, @Nullable SpawnGroupData spawnData) {
         var event = new MobSpawnEvent.FinalizeSpawn(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, null, null);
-        boolean cancel = post(event);
+        boolean cancel = MobSpawnEvent.FinalizeSpawn.BUS.post(event);
 
         if (!cancel)
             return mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnReason(), event.getSpawnData());
@@ -355,95 +333,95 @@ public final class ForgeEventFactory {
      */
     @Nullable
     public static MobSpawnEvent.FinalizeSpawn onFinalizeSpawnSpawner(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, @Nullable SpawnGroupData spawnData, @Nullable CompoundTag spawnTag, BaseSpawner spawner) {
-        return fire(new MobSpawnEvent.FinalizeSpawn(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, EntitySpawnReason.SPAWNER, spawnData, spawnTag, spawner));
+        return MobSpawnEvent.FinalizeSpawn.BUS.fire(new MobSpawnEvent.FinalizeSpawn(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, EntitySpawnReason.SPAWNER, spawnData, spawnTag, spawner));
     }
 
     public static Result canEntityDespawn(Mob entity, ServerLevelAccessor level) {
-        return fire(new AllowDespawn(entity, level)).getResult();
+        return AllowDespawn.BUS.fire(new AllowDespawn(entity, level)).getResult();
     }
 
     public static int getItemBurnTime(@NotNull ItemStack itemStack, int burnTime, @Nullable RecipeType<?> recipeType) {
-        return fire(new FurnaceFuelBurnTimeEvent(itemStack, burnTime, recipeType)).getBurnTime();
+        return FurnaceFuelBurnTimeEvent.BUS.fire(new FurnaceFuelBurnTimeEvent(itemStack, burnTime, recipeType)).getBurnTime();
     }
 
     public static int getExperienceDrop(LivingEntity entity, Player attackingPlayer, int originalExperience) {
        var event = new LivingExperienceDropEvent(entity, attackingPlayer, originalExperience);
-       if (post(event))
+       if (LivingExperienceDropEvent.BUS.post(event))
            return 0;
        return event.getDroppedExperience();
     }
 
     public static int getMaxSpawnPackSize(Mob entity) {
-        var maxCanSpawnEvent = fire(new LivingPackSizeEvent(entity));
+        var maxCanSpawnEvent = LivingPackSizeEvent.BUS.fire(new LivingPackSizeEvent(entity));
         return maxCanSpawnEvent.getResult() == Result.ALLOW ? maxCanSpawnEvent.getMaxPackSize() : entity.getMaxSpawnClusterSize();
     }
 
     public static Component getPlayerDisplayName(Player player, Component username) {
-        return fire(new PlayerEvent.NameFormat(player, username)).getDisplayname();
+        return PlayerEvent.NameFormat.BUS.fire(new PlayerEvent.NameFormat(player, username)).getDisplayname();
     }
 
     public static Component getPlayerTabListDisplayName(Player player) {
-        return fire(new PlayerEvent.TabListNameFormat(player)).getDisplayName();
+        return PlayerEvent.TabListNameFormat.BUS.fire(new PlayerEvent.TabListNameFormat(player)).getDisplayName();
     }
 
     public static BlockState fireFluidPlaceBlockEvent(LevelAccessor level, BlockPos pos, BlockPos liquidPos, BlockState state) {
-        return fire(new BlockEvent.FluidPlaceBlockEvent(level, pos, liquidPos, state)).getNewState();
+        return BlockEvent.FluidPlaceBlockEvent.BUS.fire(new BlockEvent.FluidPlaceBlockEvent(level, pos, liquidPos, state)).getNewState();
     }
 
     public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags) {
-        return fire(new ItemTooltipEvent(itemStack, entityPlayer, list, flags));
+        return ItemTooltipEvent.BUS.fire(new ItemTooltipEvent(itemStack, entityPlayer, list, flags));
     }
 
     public static SummonAidEvent fireZombieSummonAid(Zombie zombie, Level level, int x, int y, int z, LivingEntity attacker, double summonChance) {
-        return fire(new SummonAidEvent(zombie, level, x, y, z, attacker, summonChance));
+        return SummonAidEvent.BUS.fire(new SummonAidEvent(zombie, level, x, y, z, attacker, summonChance));
     }
 
     public static boolean onEntityStruckByLightning(Entity entity, LightningBolt bolt) {
-        return post(new EntityStruckByLightningEvent(entity, bolt));
+        return EntityStruckByLightningEvent.BUS.post(new EntityStruckByLightningEvent(entity, bolt));
     }
 
     public static int onItemUseStart(LivingEntity entity, ItemStack item, int duration) {
         var event = new LivingEntityUseItemEvent.Start(entity, item, duration);
-        return post(event) ? -1 : event.getDuration();
+        return LivingEntityUseItemEvent.Start.BUS.post(event) ? -1 : event.getDuration();
     }
 
     public static int onItemUseTick(LivingEntity entity, ItemStack item, int duration) {
         var event = new LivingEntityUseItemEvent.Tick(entity, item, duration);
-        return post(event) ? -1 : event.getDuration();
+        return LivingEntityUseItemEvent.Tick.BUS.post(event) ? -1 : event.getDuration();
     }
 
     public static boolean onUseItemStop(LivingEntity entity, ItemStack item, int duration) {
-        return post(new LivingEntityUseItemEvent.Stop(entity, item, duration));
+        return LivingEntityUseItemEvent.Stop.BUS.post(new LivingEntityUseItemEvent.Stop(entity, item, duration));
     }
 
     public static ItemStack onItemUseFinish(LivingEntity entity, ItemStack item, int duration, ItemStack result) {
-        return fire(new LivingEntityUseItemEvent.Finish(entity, item, duration, result)).getResultStack();
+        return LivingEntityUseItemEvent.Finish.BUS.fire(new LivingEntityUseItemEvent.Finish(entity, item, duration, result)).getResultStack();
     }
 
     public static void onStartEntityTracking(Entity entity, Player player) {
-        post(new PlayerEvent.StartTracking(player, entity));
+        PlayerEvent.StartTracking.BUS.post(new PlayerEvent.StartTracking(player, entity));
     }
 
     public static void onStopEntityTracking(Entity entity, Player player) {
-        post(new PlayerEvent.StopTracking(player, entity));
+        PlayerEvent.StopTracking.BUS.post(new PlayerEvent.StopTracking(player, entity));
     }
 
     public static void firePlayerLoadingEvent(Player player, File playerDirectory, String uuidString) {
-        post(new PlayerEvent.LoadFromFile(player, playerDirectory, uuidString));
+        PlayerEvent.LoadFromFile.BUS.post(new PlayerEvent.LoadFromFile(player, playerDirectory, uuidString));
     }
 
     public static void firePlayerSavingEvent(Player player, File playerDirectory, String uuidString) {
-        post(new PlayerEvent.SaveToFile(player, playerDirectory, uuidString));
+        PlayerEvent.SaveToFile.BUS.post(new PlayerEvent.SaveToFile(player, playerDirectory, uuidString));
     }
 
     public static void firePlayerLoadingEvent(Player player, PlayerDataStorage playerFileData, String uuidString) {
-        post(new PlayerEvent.LoadFromFile(player, playerFileData.getPlayerDataFolder(), uuidString));
+        PlayerEvent.LoadFromFile.BUS.post(new PlayerEvent.LoadFromFile(player, playerFileData.getPlayerDataFolder(), uuidString));
     }
 
     @Nullable
     public static BlockState onToolUse(BlockState originalState, UseOnContext context, ToolAction toolAction, boolean simulate) {
         var event = new BlockToolModificationEvent(originalState, context, toolAction, simulate);
-        return post(event) ? null : event.getFinalState();
+        return BlockToolModificationEvent.BUS.post(event) ? null : event.getFinalState();
     }
 
     public static int onApplyBonemeal(@Nullable Player player, Level level, BlockPos pos, BlockState state, ItemStack stack) {
@@ -451,7 +429,7 @@ public final class ForgeEventFactory {
             return 0;
 
         var event = new BonemealEvent(player, level, pos, state, stack);
-        if (post(event)) return -1;
+        if (BonemealEvent.BUS.post(event)) return -1;
         if (event.getResult() == Result.ALLOW) {
             if (!level.isClientSide)
                 stack.shrink(1);
@@ -463,7 +441,7 @@ public final class ForgeEventFactory {
     @Nullable
     public static InteractionResult onBucketUse(@NotNull Player player, @NotNull Level level, @NotNull ItemStack stack, @Nullable HitResult target) {
         var event = new FillBucketEvent(player, stack, level, target);
-        if (post(event))
+        if (FillBucketEvent.BUS.post(event))
             return InteractionResult.FAIL;
 
         if (event.getResult() == Result.ALLOW) {
@@ -483,28 +461,30 @@ public final class ForgeEventFactory {
     }
 
     public static PlayLevelSoundEvent.AtEntity onPlaySoundAtEntity(Entity entity, Holder<SoundEvent> name, SoundSource category, float volume, float pitch) {
-        return fire(new PlayLevelSoundEvent.AtEntity(entity, name, category, volume, pitch));
+        var event = new PlayLevelSoundEvent.AtEntity(entity, name, category, volume, pitch);
+        return PlayLevelSoundEvent.AtEntity.BUS.post(event) ? null : event;
     }
 
     public static PlayLevelSoundEvent.AtPosition onPlaySoundAtPosition(Level level, double x, double y, double z, Holder<SoundEvent> name, SoundSource category, float volume, float pitch) {
-        return fire(new PlayLevelSoundEvent.AtPosition(level, new Vec3(x, y, z), name, category, volume, pitch));
+        var event = new PlayLevelSoundEvent.AtPosition(level, new Vec3(x, y, z), name, category, volume, pitch);
+        return PlayLevelSoundEvent.AtPosition.BUS.post(event) ? null : event;
     }
 
     public static int onItemExpire(ItemEntity entity, @NotNull ItemStack item) {
         if (item.isEmpty()) return -1;
         var event = new ItemExpireEvent(entity, (item.isEmpty() ? 6000 : item.getItem().getEntityLifespan(item, entity.level())));
-        if (!post(event)) return -1;
+        if (!ItemExpireEvent.BUS.post(event)) return -1;
         return event.getExtraLife();
     }
 
     public static int onItemPickup(ItemEntity entityItem, Player player) {
         var event = new EntityItemPickupEvent(player, entityItem);
-        if (post(event)) return -1;
+        if (EntityItemPickupEvent.BUS.post(event)) return -1;
         return event.getResult() == Result.ALLOW ? 1 : 0;
     }
 
     public static boolean canMountEntity(Entity entityMounting, Entity entityBeingMounted, boolean isMounting) {
-        boolean isCanceled = post(new EntityMountEvent(entityMounting, entityBeingMounted, entityMounting.level(), isMounting));
+        boolean isCanceled = EntityMountEvent.BUS.post(new EntityMountEvent(entityMounting, entityBeingMounted, entityMounting.level(), isMounting));
 
         if(isCanceled) {
             entityMounting.absMoveTo(entityMounting.getX(), entityMounting.getY(), entityMounting.getZ(), entityMounting.yRotO, entityMounting.xRotO);
@@ -514,52 +494,52 @@ public final class ForgeEventFactory {
     }
 
     public static boolean onAnimalTame(Animal animal, Player tamer) {
-        return post(new AnimalTameEvent(animal, tamer));
+        return AnimalTameEvent.BUS.post(new AnimalTameEvent(animal, tamer));
     }
 
     public static boolean onPlayerPickupXp(Player player, ExperienceOrb orb) {
-        return post(new PlayerXpEvent.PickupXp(player, orb));
+        return PlayerXpEvent.PickupXp.BUS.post(new PlayerXpEvent.PickupXp(player, orb));
     }
 
     public static Player.BedSleepingProblem onPlayerSleepInBed(Player player, Optional<BlockPos> pos) {
-        return fire(new PlayerSleepInBedEvent(player, pos)).getResultStatus();
+        return PlayerSleepInBedEvent.BUS.fire(new PlayerSleepInBedEvent(player, pos)).getResultStatus();
     }
 
     public static void onPlayerWakeup(Player player, boolean wakeImmediately, boolean updateLevel) {
-        post(new PlayerWakeUpEvent(player, wakeImmediately, updateLevel));
+        PlayerWakeUpEvent.BUS.post(new PlayerWakeUpEvent(player, wakeImmediately, updateLevel));
     }
 
     public static void onPlayerFall(Player player, float distance, float multiplier) {
-        post(new PlayerFlyableFallEvent(player, distance, multiplier));
+        PlayerFlyableFallEvent.BUS.post(new PlayerFlyableFallEvent(player, distance, multiplier));
     }
 
     public static boolean onPlayerSpawnSet(Player player, ResourceKey<Level> levelKey, BlockPos pos, boolean forced) {
-        return post(new PlayerSetSpawnEvent(player, levelKey, pos, forced));
+        return PlayerSetSpawnEvent.BUS.post(new PlayerSetSpawnEvent(player, levelKey, pos, forced));
     }
 
     public static PlayerSpawnPhantomsEvent onPlayerSpawnPhantom(Player player, int phantomsToSpawn) {
-        return fire(new PlayerSpawnPhantomsEvent(player, phantomsToSpawn));
+        return PlayerSpawnPhantomsEvent.BUS.fire(new PlayerSpawnPhantomsEvent(player, phantomsToSpawn));
     }
 
     public static void onPlayerClone(Player player, Player oldPlayer, boolean wasDeath) {
-        post(new PlayerEvent.Clone(player, oldPlayer, wasDeath));
+        PlayerEvent.Clone.BUS.post(new PlayerEvent.Clone(player, oldPlayer, wasDeath));
     }
 
     public static boolean onExplosionStart(Level level, Explosion explosion) {
-        return post(new ExplosionEvent.Start(level, explosion));
+        return ExplosionEvent.Start.BUS.post(new ExplosionEvent.Start(level, explosion));
     }
 
     public static void onExplosionDetonate(Level level, Explosion explosion, List<BlockPos> blocks, List<Entity> entities, double diameter) {
-        post(new ExplosionEvent.Detonate(level, explosion, blocks, entities));
+        ExplosionEvent.Detonate.BUS.post(new ExplosionEvent.Detonate(level, explosion, blocks, entities));
     }
 
     public static boolean onCreateWorldSpawn(Level level, ServerLevelData settings) {
-        return post(new LevelEvent.CreateSpawnPosition(level, settings));
+        return LevelEvent.CreateSpawnPosition.BUS.post(new LevelEvent.CreateSpawnPosition(level, settings));
     }
 
     public static float onLivingHeal(LivingEntity entity, float amount) {
         var event = new LivingHealEvent(entity, amount);
-        return (post(event) ? 0 : event.getAmount());
+        return (LivingHealEvent.BUS.post(event) ? 0 : event.getAmount());
     }
 
     public static boolean onPotionAttemptBrew(NonNullList<ItemStack> stacks) {
@@ -568,7 +548,7 @@ public final class ForgeEventFactory {
             tmp.set(x, stacks.get(x).copy());
 
         var event = new PotionBrewEvent.Pre(tmp);
-        if (post(event)) {
+        if (PotionBrewEvent.Pre.BUS.post(event)) {
             boolean changed = false;
             for (int x = 0; x < stacks.size(); x++) {
                 changed |= ItemStack.matches(tmp.get(x), stacks.get(x));
@@ -582,11 +562,11 @@ public final class ForgeEventFactory {
     }
 
     public static void onPotionBrewed(NonNullList<ItemStack> brewingItemStacks) {
-        post(new PotionBrewEvent.Post(brewingItemStacks));
+        PotionBrewEvent.Post.BUS.post(new PotionBrewEvent.Post(brewingItemStacks));
     }
 
     public static void onPlayerBrewedPotion(Player player, ItemStack stack) {
-        post(new PlayerBrewedPotionEvent(player, stack));
+        PlayerBrewedPotionEvent.BUS.post(new PlayerBrewedPotionEvent(player, stack));
     }
 
     @Nullable
@@ -602,15 +582,13 @@ public final class ForgeEventFactory {
 
     @Nullable
     private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent) {
-        post(event);
+        // Todo: [Forge][EventFactory] gatherCapabilities event post
+//        post(event);
         return !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
     }
 
     public static boolean fireSleepingLocationCheck(LivingEntity player, BlockPos sleepingLocation) {
-        var evt = new SleepingLocationCheckEvent(player, sleepingLocation);
-        post(evt);
-
-        Result canContinueSleep = evt.getResult();
+        Result canContinueSleep = SleepingLocationCheckEvent.BUS.fire(new SleepingLocationCheckEvent(player, sleepingLocation)).getResult();
         if (canContinueSleep == Result.DEFAULT)
             return player.getSleepingPos().map(pos -> player.level().getBlockState(pos).isBed(player.level(), pos, player)).orElse(false);
         else
@@ -618,8 +596,7 @@ public final class ForgeEventFactory {
     }
 
     public static boolean onSleepingTimeCheck(Player player, Optional<BlockPos> sleepingLocation) {
-        var evt = new SleepingTimeCheckEvent(player, sleepingLocation);
-        post(evt);
+        var evt = SleepingTimeCheckEvent.BUS.fire(new SleepingTimeCheckEvent(player, sleepingLocation));
 
         var canContinueSleep = evt.getResult();
         if (canContinueSleep == Result.DEFAULT)
@@ -630,20 +607,20 @@ public final class ForgeEventFactory {
 
     public static InteractionResult onArrowNock(ItemStack item, Level level, Player player, InteractionHand hand, boolean hasAmmo) {
         var event = new ArrowNockEvent(player, item, hand, level, hasAmmo);
-        if (post(event))
+        if (ArrowNockEvent.BUS.post(event))
             return InteractionResult.FAIL;
         return event.getAction();
     }
 
     public static int onArrowLoose(ItemStack stack, Level level, Player player, int charge, boolean hasAmmo) {
         var event = new ArrowLooseEvent(player, stack, level, charge, hasAmmo);
-        if (post(event))
+        if (ArrowLooseEvent.BUS.post(event))
             return -1;
         return event.getCharge();
     }
 
     public static ProjectileImpactEvent.ImpactResult onProjectileImpactResult(Projectile projectile, HitResult ray) {
-        return fire(new ProjectileImpactEvent(projectile, ray)).getImpactResult();
+        return ProjectileImpactEvent.BUS.fire(new ProjectileImpactEvent(projectile, ray)).getImpactResult();
     }
 
     public static boolean onProjectileImpact(Projectile projectile, HitResult ray) {
@@ -652,333 +629,338 @@ public final class ForgeEventFactory {
 
     public static @Nullable LootTable onLoadLootTable(ResourceLocation name, LootTable table) {
         var event = new LootTableLoadEvent(name, table);
-        return post(event) ? null : event.getTable();
+        return LootTableLoadEvent.BUS.post(event) ? null : event.getTable();
     }
 
     public static boolean canCreateFluidSource(Level level, BlockPos pos, BlockState state, boolean def) {
-        var result = fire(new CreateFluidSourceEvent(level, pos, state)).getResult();
+        var result = CreateFluidSourceEvent.BUS.fire(new CreateFluidSourceEvent(level, pos, state)).getResult();
         return result == Result.DEFAULT ? def : result == Result.ALLOW;
     }
 
     public static Optional<PortalShape> onTrySpawnPortal(LevelAccessor level, BlockPos pos, Optional<PortalShape> size) {
         if (!size.isPresent()) return size;
-        return !post(new BlockEvent.PortalSpawnEvent(level, pos, level.getBlockState(pos), size.get())) ? size : Optional.empty();
+        return !BlockEvent.PortalSpawnEvent.BUS.post(new BlockEvent.PortalSpawnEvent(level, pos, level.getBlockState(pos), size.get())) ? size : Optional.empty();
     }
 
     public static int onEnchantmentLevelSet(Level level, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int enchantmentLevel) {
-        return fire(new EnchantmentLevelSetEvent(level, pos, enchantRow, power, itemStack, enchantmentLevel)).getEnchantLevel();
+        return EnchantmentLevelSetEvent.BUS.fire(new EnchantmentLevelSetEvent(level, pos, enchantRow, power, itemStack, enchantmentLevel)).getEnchantLevel();
     }
 
     public static boolean onEntityDestroyBlock(LivingEntity entity, BlockPos pos, BlockState state) {
-        return !post(new LivingDestroyBlockEvent(entity, pos, state));
+        return !LivingDestroyBlockEvent.BUS.post(new LivingDestroyBlockEvent(entity, pos, state));
     }
 
     public static boolean getMobGriefingEvent(ServerLevel level, @Nullable Entity entity) {
         if (entity == null)
             return level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
 
-        var result = fire(new EntityMobGriefingEvent(entity)).getResult();
+        var result = EntityMobGriefingEvent.BUS.fire(new EntityMobGriefingEvent(entity)).getResult();
         return result == Result.DEFAULT ? level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) : result == Result.ALLOW;
     }
 
     @SuppressWarnings("removal")
     public static SaplingGrowTreeEvent blockGrowFeature(LevelAccessor level, RandomSource randomSource, BlockPos pos, @Nullable Holder<ConfiguredFeature<?, ?>> holder) {
-        return fire(new SaplingGrowTreeEvent(level, randomSource, pos, holder));
+        return SaplingGrowTreeEvent.BUS.fire(new SaplingGrowTreeEvent(level, randomSource, pos, holder));
     }
 
     public static BlockState alterGround(LevelSimulatedReader level, RandomSource random, BlockPos pos, BlockState altered) {
-        return fire(new AlterGroundEvent(level, random, pos, altered)).getNewAlteredState();
+        return AlterGroundEvent.BUS.fire(new AlterGroundEvent(level, random, pos, altered)).getNewAlteredState();
     }
 
     public static void fireChunkTicketLevelUpdated(ServerLevel level, long chunkPos, int oldTicketLevel, int newTicketLevel, @Nullable ChunkHolder chunkHolder) {
         if (oldTicketLevel != newTicketLevel)
-            post(new ChunkTicketLevelUpdatedEvent(level, chunkPos, oldTicketLevel, newTicketLevel, chunkHolder));
+            ChunkTicketLevelUpdatedEvent.BUS.post(new ChunkTicketLevelUpdatedEvent(level, chunkPos, oldTicketLevel, newTicketLevel, chunkHolder));
     }
 
     public static void fireChunkWatch(ServerPlayer entity, LevelChunk chunk, ServerLevel level) {
-        post(new ChunkWatchEvent.Watch(entity, chunk, level));
+        ChunkWatchEvent.Watch.BUS.post(new ChunkWatchEvent.Watch(entity, chunk, level));
     }
 
     public static void fireChunkUnWatch(ServerPlayer entity, ChunkPos chunkpos, ServerLevel level) {
-        post(new ChunkWatchEvent.UnWatch(entity, chunkpos, level));
+        ChunkWatchEvent.UnWatch.BUS.post(new ChunkWatchEvent.UnWatch(entity, chunkpos, level));
     }
 
     public static boolean onPistonMovePre(Level level, BlockPos pos, Direction direction, boolean extending) {
-        return post(new PistonEvent.Pre(level, pos, direction, extending ? PistonEvent.PistonMoveType.EXTEND : PistonEvent.PistonMoveType.RETRACT));
+        return PistonEvent.Pre.BUS.post(new PistonEvent.Pre(level, pos, direction, extending ? PistonEvent.PistonMoveType.EXTEND : PistonEvent.PistonMoveType.RETRACT));
     }
 
     public static boolean onPistonMovePost(Level level, BlockPos pos, Direction direction, boolean extending) {
-        return post(new PistonEvent.Post(level, pos, direction, extending ? PistonEvent.PistonMoveType.EXTEND : PistonEvent.PistonMoveType.RETRACT));
+        return PistonEvent.Post.BUS.post(new PistonEvent.Post(level, pos, direction, extending ? PistonEvent.PistonMoveType.EXTEND : PistonEvent.PistonMoveType.RETRACT));
     }
 
     public static long onSleepFinished(ServerLevel level, long newTime, long minTime) {
-        return fire(new SleepFinishedTimeEvent(level, newTime, minTime)).getNewTime();
+        return SleepFinishedTimeEvent.BUS.fire(new SleepFinishedTimeEvent(level, newTime, minTime)).getNewTime();
     }
 
     @Deprecated(forRemoval = true, since = "1.21.4")
     public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, RegistryAccess registryAccess) {
-        return fire(new AddReloadListenerEvent(serverResources, registryAccess)).getListeners();
+        return AddReloadListenerEvent.BUS.fire(new AddReloadListenerEvent(serverResources, registryAccess)).getListeners();
     }
 
     public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, HolderLookup.Provider lookupProvider, @Deprecated(forRemoval = true, since = "1.21.4") RegistryAccess registryAccess) {
-        return fire(new AddReloadListenerEvent(serverResources, lookupProvider, registryAccess)).getListeners();
+        return AddReloadListenerEvent.BUS.fire(new AddReloadListenerEvent(serverResources, lookupProvider, registryAccess)).getListeners();
     }
 
     public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context) {
-        post(new RegisterCommandsEvent(dispatcher, environment, context));
+        RegisterCommandsEvent.BUS.post(new RegisterCommandsEvent(dispatcher, environment, context));
     }
 
     public static boolean canLivingConvert(LivingEntity entity, EntityType<? extends LivingEntity> outcome, Consumer<Integer> timer) {
-        return !post(new LivingConversionEvent.Pre(entity, outcome, timer));
+        return !LivingConversionEvent.Pre.BUS.post(new LivingConversionEvent.Pre(entity, outcome, timer));
     }
 
     public static void onLivingConvert(LivingEntity entity, LivingEntity outcome) {
-        post(new LivingConversionEvent.Post(entity, outcome));
+        LivingConversionEvent.Post.BUS.post(new LivingConversionEvent.Post(entity, outcome));
     }
 
     public static BabyEntitySpawnEvent onBabySpawn(Mob parentA, Mob parentB, @Nullable AgeableMob proposedChild) {
-        return fire(new BabyEntitySpawnEvent(parentA, parentB, proposedChild));
+        return BabyEntitySpawnEvent.BUS.fire(new BabyEntitySpawnEvent(parentA, parentB, proposedChild));
 
     }
 
     public static EntityTeleportEvent.TeleportCommand onEntityTeleportCommand(Entity entity, double targetX, double targetY, double targetZ) {
-        return fire(new EntityTeleportEvent.TeleportCommand(entity, targetX, targetY, targetZ));
+        var event = new EntityTeleportEvent.TeleportCommand(entity, targetX, targetY, targetZ);
+        return EntityTeleportEvent.TeleportCommand.BUS.post(event) ? null : event;
     }
 
     public static EntityTeleportEvent.SpreadPlayersCommand onEntityTeleportSpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ) {
-        return fire(new EntityTeleportEvent.SpreadPlayersCommand(entity, targetX, targetY, targetZ));
+        var event = new EntityTeleportEvent.SpreadPlayersCommand(entity, targetX, targetY, targetZ);
+        return EntityTeleportEvent.SpreadPlayersCommand.BUS.post(event) ? null : event;
     }
 
     public static EntityTeleportEvent.EnderEntity onEnderTeleport(LivingEntity entity, double targetX, double targetY, double targetZ) {
-        return fire(new EntityTeleportEvent.EnderEntity(entity, targetX, targetY, targetZ));
+        return EntityTeleportEvent.EnderEntity.BUS.fire(new EntityTeleportEvent.EnderEntity(entity, targetX, targetY, targetZ));
     }
 
     public static EntityTeleportEvent.EnderPearl onEnderPearlLand(ServerPlayer entity, double targetX, double targetY, double targetZ, ThrownEnderpearl pearlEntity, float attackDamage, HitResult hitResult) {
-        return fire(new EntityTeleportEvent.EnderPearl(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, hitResult));
+        return EntityTeleportEvent.EnderPearl.BUS.fire(new EntityTeleportEvent.EnderPearl(entity, targetX, targetY, targetZ, pearlEntity, attackDamage, hitResult));
     }
 
     public static EntityTeleportEvent.ChorusFruit onChorusFruitTeleport(LivingEntity entity, double targetX, double targetY, double targetZ) {
-        return fire(new EntityTeleportEvent.ChorusFruit(entity, targetX, targetY, targetZ));
+        return EntityTeleportEvent.ChorusFruit.BUS.fire(new EntityTeleportEvent.ChorusFruit(entity, targetX, targetY, targetZ));
     }
 
     public static boolean onPermissionChanged(GameProfile gameProfile, int newLevel, PlayerList playerList) {
         var oldLevel = playerList.getServer().getProfilePermissions(gameProfile);
         var player = playerList.getPlayer(gameProfile.getId());
         if (newLevel != oldLevel && player != null)
-            return post(new PermissionsChangedEvent(player, newLevel, oldLevel));
+            return PermissionsChangedEvent.BUS.post(new PermissionsChangedEvent(player, newLevel, oldLevel));
         return false;
     }
 
     public static void onPlayerChangedDimension(Player player, ResourceKey<Level> fromDim, ResourceKey<Level> toDim) {
-        post(new PlayerEvent.PlayerChangedDimensionEvent(player, fromDim, toDim));
+        PlayerEvent.PlayerChangedDimensionEvent.BUS.post(new PlayerEvent.PlayerChangedDimensionEvent(player, fromDim, toDim));
     }
 
     public static void firePlayerLoggedIn(Player player) {
-        post(new PlayerEvent.PlayerLoggedInEvent(player));
+        PlayerEvent.PlayerLoggedInEvent.BUS.post(new PlayerEvent.PlayerLoggedInEvent(player));
     }
 
     public static void firePlayerLoggedOut(Player player) {
-        post(new PlayerEvent.PlayerLoggedOutEvent(player));
+        PlayerEvent.PlayerLoggedOutEvent.BUS.post(new PlayerEvent.PlayerLoggedOutEvent(player));
     }
 
     public static void firePlayerRespawnEvent(Player player, boolean endConquered) {
-        post(new PlayerEvent.PlayerRespawnEvent(player, endConquered));
+        PlayerEvent.PlayerRespawnEvent.BUS.post(new PlayerEvent.PlayerRespawnEvent(player, endConquered));
     }
 
     public static void firePlayerItemPickupEvent(Player player, ItemEntity item, ItemStack clone) {
-        post(new PlayerEvent.ItemPickupEvent(player, item, clone));
+        PlayerEvent.ItemPickupEvent.BUS.post(new PlayerEvent.ItemPickupEvent(player, item, clone));
     }
 
     public static void firePlayerCraftingEvent(Player player, ItemStack crafted, Container craftMatrix) {
-        post(new PlayerEvent.ItemCraftedEvent(player, crafted, craftMatrix));
+        PlayerEvent.ItemCraftedEvent.BUS.post(new PlayerEvent.ItemCraftedEvent(player, crafted, craftMatrix));
     }
 
     public static void firePlayerSmeltedEvent(Player player, ItemStack smelted) {
-        post(new PlayerEvent.ItemSmeltedEvent(player, smelted));
+        PlayerEvent.ItemSmeltedEvent.BUS.post(new PlayerEvent.ItemSmeltedEvent(player, smelted));
     }
 
     public static void onPlayerPreTick(Player player) {
-        post(new TickEvent.PlayerTickEvent.Pre(player));
+        TickEvent.PlayerTickEvent.Pre.BUS.post(new TickEvent.PlayerTickEvent.Pre(player));
     }
 
     public static void onPlayerPostTick(Player player) {
-        post(new TickEvent.PlayerTickEvent.Post(player));
+        TickEvent.PlayerTickEvent.Post.BUS.post(new TickEvent.PlayerTickEvent.Post(player));
     }
 
     public static void onPreLevelTick(Level level, BooleanSupplier haveTime) {
-        post(new TickEvent.LevelTickEvent.Pre(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, level, haveTime));
+        TickEvent.LevelTickEvent.Pre.BUS.post(new TickEvent.LevelTickEvent.Pre(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, level, haveTime));
     }
 
     public static void onPostLevelTick(Level level, BooleanSupplier haveTime) {
-        post(new TickEvent.LevelTickEvent.Post(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, level, haveTime));
+        TickEvent.LevelTickEvent.Post.BUS.post(new TickEvent.LevelTickEvent.Post(level.isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER, level, haveTime));
     }
 
     public static void onPreClientTick() {
-        post(new TickEvent.ClientTickEvent.Pre());
+        TickEvent.ClientTickEvent.Pre.BUS.post(new TickEvent.ClientTickEvent.Pre());
     }
 
     public static void onPostClientTick() {
-        post(new TickEvent.ClientTickEvent.Post());
+        TickEvent.ClientTickEvent.Post.BUS.post(new TickEvent.ClientTickEvent.Post());
     }
 
     public static void onPreServerTick(BooleanSupplier haveTime, MinecraftServer server) {
-        post(new TickEvent.ServerTickEvent.Pre(haveTime, server));
+        TickEvent.ServerTickEvent.Pre.BUS.post(new TickEvent.ServerTickEvent.Pre(haveTime, server));
     }
 
     public static void onPostServerTick(BooleanSupplier haveTime, MinecraftServer server) {
-        post(new TickEvent.ServerTickEvent.Post(haveTime, server));
+        TickEvent.ServerTickEvent.Post.BUS.post(new TickEvent.ServerTickEvent.Post(haveTime, server));
     }
 
     public static WeightedRandomList<MobSpawnSettings.SpawnerData> getPotentialSpawns(LevelAccessor level, MobCategory category, BlockPos pos, WeightedRandomList<MobSpawnSettings.SpawnerData> oldList) {
         LevelEvent.PotentialSpawns event = new LevelEvent.PotentialSpawns(level, category, pos, oldList);
-        if (post(event))
+        if (LevelEvent.PotentialSpawns.BUS.post(event))
             return WeightedRandomList.create();
         //System.out.println("List: " + oldList.unwrap() + " " + event.getSpawnerDataList());
         return WeightedRandomList.create(event.getSpawnerDataList());
     }
 
     public static void onAdvancementEarned(Player player, AdvancementHolder holder) {
-        post(new AdvancementEarnEvent(player, holder));
+        AdvancementEarnEvent.BUS.post(new AdvancementEarnEvent(player, holder));
     }
 
     public static void onAdvancementGrant(Player player, AdvancementHolder holder, AdvancementProgress advancementProgress, String criterion) {
-        post(new AdvancementProgressEvent(player, holder, advancementProgress, criterion, ProgressType.GRANT));
+        AdvancementProgressEvent.BUS.post(new AdvancementProgressEvent(player, holder, advancementProgress, criterion, ProgressType.GRANT));
     }
 
     public static void onAdvancementRevoke(Player player, AdvancementHolder holder, AdvancementProgress advancementProgress, String criterion) {
-        post(new AdvancementProgressEvent(player, holder, advancementProgress, criterion, ProgressType.REVOKE));
+        AdvancementProgressEvent.BUS.post(new AdvancementProgressEvent(player, holder, advancementProgress, criterion, ProgressType.REVOKE));
     }
 
     public static void onEntityConstructing(Entity entity) {
-        post(new EntityEvent.EntityConstructing(entity));
+        EntityEvent.EntityConstructing.BUS.post(new EntityEvent.EntityConstructing(entity));
     }
 
     public static void onPlayerOpenContainer(ServerPlayer player, AbstractContainerMenu menu) {
-        post(new PlayerContainerEvent.Open(player, menu));
+        PlayerContainerEvent.Open.BUS.post(new PlayerContainerEvent.Open(player, menu));
     }
 
     public static void onPlayerCloseContainer(ServerPlayer player, AbstractContainerMenu menu) {
-        post(new PlayerContainerEvent.Close(player, menu));
+        PlayerContainerEvent.Close.BUS.post(new PlayerContainerEvent.Close(player, menu));
     }
 
     public static boolean onTravelToDimension(Entity entity, ResourceKey<Level> dimension) {
-        return post(new EntityTravelToDimensionEvent(entity, dimension));
+        return EntityTravelToDimensionEvent.BUS.post(new EntityTravelToDimensionEvent(entity, dimension));
     }
 
     public static void onChunkUnload(ChunkAccess chunk) {
-        post(new ChunkEvent.Unload(chunk));
+        ChunkEvent.Unload.BUS.post(new ChunkEvent.Unload(chunk));
     }
 
     public static void onChunkLoad(ChunkAccess chunk, boolean newChunk) {
-        post(new ChunkEvent.Load(chunk, newChunk));
+        ChunkEvent.Load.BUS.post(new ChunkEvent.Load(chunk, newChunk));
     }
 
     public static void onLevelUnload(Level level) {
-         post(new LevelEvent.Unload(level));
+        LevelEvent.Unload.BUS.post(new LevelEvent.Unload(level));
     }
 
     public static void onLevelLoad(Level level) {
-         post(new LevelEvent.Load(level));
+        LevelEvent.Load.BUS.post(new LevelEvent.Load(level));
     }
 
     public static void onLevelSave(Level level) {
-        post(new LevelEvent.Save(level));
+        LevelEvent.Save.BUS.post(new LevelEvent.Save(level));
     }
 
     public static void onChunkDataSave(ChunkAccess chunk, LevelAccessor world, SerializableChunkData data) {
-        post(new ChunkDataEvent.Save(chunk, world, data));
+        ChunkDataEvent.Save.BUS.post(new ChunkDataEvent.Save(chunk, world, data));
     }
 
     public static void onChunkDataLoad(ChunkAccess chunk, SerializableChunkData data, ChunkType status) {
-        post(new ChunkDataEvent.Load(chunk, data, status));
+        ChunkDataEvent.Load.BUS.post(new ChunkDataEvent.Load(chunk, data, status));
     }
 
     public static void onGameShuttingDown() {
-        post(new GameShuttingDownEvent());
+        GameShuttingDownEvent.BUS.post(new GameShuttingDownEvent());
     }
 
     public static void gatherLoginConfigTasks(Connection connection, Consumer<ConfigurationTask> add) {
-        post(new GatherLoginConfigurationTasksEvent(connection, add));
+        GatherLoginConfigurationTasksEvent.BUS.post(new GatherLoginConfigurationTasksEvent(connection, add));
     }
 
     public static void onConnectionStart(Connection connection) {
-        post(new ConnectionStartEvent(connection));
+        ConnectionStartEvent.BUS.post(new ConnectionStartEvent(connection));
     }
 
     public static void onChannelRegistrationChange(Connection connection, ChannelRegistrationChangeEvent.Type changeType, HashSet<ResourceLocation> changed) {
-        post(new ChannelRegistrationChangeEvent(connection, changeType, changed));
+        ChannelRegistrationChangeEvent.BUS.post(new ChannelRegistrationChangeEvent(connection, changeType, changed));
     }
 
     public static LivingSwapItemsEvent.Hands onLivingSwapHandItems(LivingEntity entity) {
-        return fire(new LivingSwapItemsEvent.Hands(entity));
+        var event = new LivingSwapItemsEvent.Hands(entity);
+        return LivingSwapItemsEvent.Hands.BUS.post(event) ? null : event;
     }
 
     public static ShieldBlockEvent onShieldBlock(LivingEntity blocker, DamageSource source, float blocked) {
-        return fire(new ShieldBlockEvent(blocker, source, blocked));
+        return ShieldBlockEvent.BUS.fire(new ShieldBlockEvent(blocker, source, blocked));
     }
 
     public static void onEntityEnterSection(Entity entity, long packedOldPos, long packedNewPos) {
-        post(new EntityEvent.EnteringSection(entity, packedOldPos, packedNewPos));
+        EntityEvent.EnteringSection.BUS.post(new EntityEvent.EnteringSection(entity, packedOldPos, packedNewPos));
     }
 
     public static boolean onLivingTick(LivingEntity entity) {
-        return post(new LivingEvent.LivingTickEvent(entity));
+        return LivingEvent.LivingTickEvent.BUS.post(new LivingEvent.LivingTickEvent(entity));
     }
 
     public static LivingFallEvent onLivingFall(LivingEntity entity, float distance, float damageMultiplier) {
-        return fire(new LivingFallEvent(entity, distance, damageMultiplier));
+        var event = new LivingFallEvent(entity, distance, damageMultiplier);
+        return LivingFallEvent.BUS.post(event) ? null : event;
     }
 
     public static LivingBreatheEvent onLivingBreathe(LivingEntity entity, boolean canBreathe, int consumeAirAmount, int refillAirAmount, boolean canRefillAir) {
-        return fire(new LivingBreatheEvent(entity, canBreathe, consumeAirAmount, refillAirAmount, canRefillAir));
+        return LivingBreatheEvent.BUS.fire(new LivingBreatheEvent(entity, canBreathe, consumeAirAmount, refillAirAmount, canRefillAir));
     }
 
     public static LivingDrownEvent onLivingDrown(LivingEntity entity, boolean isDrowning, float damageAmount, int bubbleCount) {
-        return fire(new LivingDrownEvent(entity, isDrowning, damageAmount, bubbleCount));
+        return LivingDrownEvent.BUS.fire(new LivingDrownEvent(entity, isDrowning, damageAmount, bubbleCount));
     }
 
     public static LivingKnockBackEvent onLivingKnockBack(LivingEntity target, float strength, double ratioX, double ratioZ) {
-        return fire(new LivingKnockBackEvent(target, strength, ratioX, ratioZ));
+        var event = new LivingKnockBackEvent(target, strength, ratioX, ratioZ);
+        return LivingKnockBackEvent.BUS.post(event) ? null : event;
     }
 
     public static boolean onLivingDeath(LivingEntity entity, DamageSource src) {
-        return post(new LivingDeathEvent(entity, src));
+        return LivingDeathEvent.BUS.post(new LivingDeathEvent(entity, src));
     }
 
     public static boolean onLivingDrops(LivingEntity entity, DamageSource source, Collection<ItemEntity> drops, boolean recentlyHit) {
-        return post(new LivingDropsEvent(entity, source, drops, recentlyHit));
+        return LivingDropsEvent.BUS.post(new LivingDropsEvent(entity, source, drops, recentlyHit));
     }
 
     public static void onLeftClickEmpty(Player player) {
-        post(new PlayerInteractEvent.LeftClickEmpty(player));
+        PlayerInteractEvent.LeftClickEmpty.BUS.post(new PlayerInteractEvent.LeftClickEmpty(player));
     }
 
     public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(Player player, BlockPos pos, Direction face, ServerboundPlayerActionPacket.Action action) {
-        return fire(new PlayerInteractEvent.LeftClickBlock(player, pos, face, PlayerInteractEvent.LeftClickBlock.Action.convert(action)));
+        return PlayerInteractEvent.LeftClickBlock.BUS.fire(new PlayerInteractEvent.LeftClickBlock(player, pos, face, PlayerInteractEvent.LeftClickBlock.Action.convert(action)));
     }
 
     public static PlayerInteractEvent.LeftClickBlock onLeftClickBlockHold(Player player, BlockPos pos, Direction face) {
-        return fire(new PlayerInteractEvent.LeftClickBlock(player, pos, face, PlayerInteractEvent.LeftClickBlock.Action.CLIENT_HOLD));
+        return PlayerInteractEvent.LeftClickBlock.BUS.fire(new PlayerInteractEvent.LeftClickBlock(player, pos, face, PlayerInteractEvent.LeftClickBlock.Action.CLIENT_HOLD));
     }
 
     public static PlayerInteractEvent.RightClickBlock onRightClickBlock(Player player, InteractionHand hand, BlockPos pos, BlockHitResult hitVec) {
-        return fire(new PlayerInteractEvent.RightClickBlock(player, hand, pos, hitVec));
+        return PlayerInteractEvent.RightClickBlock.BUS.fire(new PlayerInteractEvent.RightClickBlock(player, hand, pos, hitVec));
     }
 
     public static PlayerInteractEvent.RightClickItem onRightClickItem(Player player, InteractionHand hand) {
-        return fire(new PlayerInteractEvent.RightClickItem(player, hand));
+        return PlayerInteractEvent.RightClickItem.BUS.fire(new PlayerInteractEvent.RightClickItem(player, hand));
     }
 
     public static PlayerInteractEvent.EntityInteract onEntityInteract(Player player, Entity entity, InteractionHand hand) {
-        return fire(new PlayerInteractEvent.EntityInteract(player, hand, entity));
+        return PlayerInteractEvent.EntityInteract.BUS.fire(new PlayerInteractEvent.EntityInteract(player, hand, entity));
     }
 
     public static PlayerInteractEvent.EntityInteractSpecific onEntityInteractSpecific(Player player, Entity entity, InteractionHand hand, Vec3 vec3d) {
-        return fire(new PlayerInteractEvent.EntityInteractSpecific(player, hand, entity, vec3d));
+        return PlayerInteractEvent.EntityInteractSpecific.BUS.fire(new PlayerInteractEvent.EntityInteractSpecific(player, hand, entity, vec3d));
     }
 
     public static void onRightClickEmpty(Player player, InteractionHand hand) {
-        post(new PlayerInteractEvent.RightClickEmpty(player, hand));
+        PlayerInteractEvent.RightClickEmpty.BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
     }
 
     // TODO: Remove from mod bus - Lex 04222024
@@ -987,110 +969,116 @@ public final class ForgeEventFactory {
     }
 
     public static boolean onEntityJoinLevel(Entity entity, Level level) {
-        return post(new EntityJoinLevelEvent(entity, level));
+        return EntityJoinLevelEvent.BUS.post(new EntityJoinLevelEvent(entity, level));
     }
     public static boolean onEntityJoinLevel(Entity entity, Level level, boolean loadedFromDisk) {
-        return post(new EntityJoinLevelEvent(entity, level, loadedFromDisk));
+        return EntityJoinLevelEvent.BUS.post(new EntityJoinLevelEvent(entity, level, loadedFromDisk));
     }
 
     public static boolean onEntityLeaveLevel(Entity entity, Level level) {
-        return post(new EntityLeaveLevelEvent(entity, level));
+        return EntityLeaveLevelEvent.BUS.post(new EntityLeaveLevelEvent(entity, level));
     }
 
     public static void onDifficultyChange(Difficulty difficulty, Difficulty oldDifficulty) {
-        post(new DifficultyChangeEvent(difficulty, oldDifficulty));
+        DifficultyChangeEvent.BUS.post(new DifficultyChangeEvent(difficulty, oldDifficulty));
     }
 
     public static void onTagsUpdated(RegistryAccess registryAccess, boolean fromClientPacket, boolean isIntegratedServerConnection) {
-        post(new TagsUpdatedEvent(registryAccess, fromClientPacket, isIntegratedServerConnection));
+        TagsUpdatedEvent.BUS.post(new TagsUpdatedEvent(registryAccess, fromClientPacket, isIntegratedServerConnection));
     }
 
     public static boolean onLivingAttackEntity(LivingEntity entity, DamageSource src, float amount) {
-        return post(new LivingAttackEvent(entity, src, amount));
+        return LivingAttackEvent.BUS.post(new LivingAttackEvent(entity, src, amount));
     }
 
     public static boolean onVanillaGameEvent(Level level, Holder<GameEvent> vanillaEvent, Vec3 pos, GameEvent.Context context) {
-        return post(new VanillaGameEvent(level, vanillaEvent.get(), pos, context));
+        return VanillaGameEvent.BUS.post(new VanillaGameEvent(level, vanillaEvent.get(), pos, context));
     }
 
     public static boolean onLivingEffectExpire(LivingEntity entity, MobEffectInstance effect) {
-        return post(new MobEffectEvent.Expired(entity, effect));
+        return MobEffectEvent.Expired.BUS.post(new MobEffectEvent.Expired(entity, effect));
     }
 
     public static boolean onLivingEffectAdd(LivingEntity entity, MobEffectInstance oldEffect, MobEffectInstance newEffect, Entity source) {
-        return post(new MobEffectEvent.Added(entity, oldEffect, newEffect, source));
+        return MobEffectEvent.Added.BUS.post(new MobEffectEvent.Added(entity, oldEffect, newEffect, source));
     }
 
     public static boolean onLivingEffectRemove(LivingEntity entity, MobEffect effect) {
-        return post(new MobEffectEvent.Remove(entity, effect));
+        return MobEffectEvent.Remove.BUS.post(new MobEffectEvent.Remove(entity, effect));
     }
 
     public static boolean onLivingEffectRemove(LivingEntity entity, MobEffectInstance effect) {
-        return post(new MobEffectEvent.Remove(entity, effect));
+        return MobEffectEvent.Remove.BUS.post(new MobEffectEvent.Remove(entity, effect));
     }
 
     public static MobEffectEvent.Applicable onLivingEffectCanApply(LivingEntity entity, MobEffectInstance effect) {
-        return fire(new MobEffectEvent.Applicable(entity, effect));
+        return MobEffectEvent.Applicable.BUS.fire(new MobEffectEvent.Applicable(entity, effect));
     }
 
     public static void onLivingEquipmentChange(LivingEntity entity, EquipmentSlot slot, ItemStack from, ItemStack to) {
-        fire(new LivingEquipmentChangeEvent(entity, slot, from, to));
+        LivingEquipmentChangeEvent.BUS.fire(new LivingEquipmentChangeEvent(entity, slot, from, to));
     }
 
     public static LivingChangeTargetEvent onLivingChangeTargetMob(LivingEntity entity, LivingEntity originalTarget) {
-        return fire(new LivingChangeTargetEvent(entity, originalTarget, LivingChangeTargetEvent.LivingTargetType.MOB_TARGET));
+        var event = new LivingChangeTargetEvent(entity, originalTarget, LivingChangeTargetEvent.LivingTargetType.MOB_TARGET);
+        return LivingChangeTargetEvent.BUS.post(event) ? null : event;
     }
 
     public static LivingChangeTargetEvent onLivingChangeTargetBehavior(LivingEntity entity, LivingEntity originalTarget) {
-        return fire(new LivingChangeTargetEvent(entity, originalTarget, LivingChangeTargetEvent.LivingTargetType.BEHAVIOR_TARGET));
+        var event = new LivingChangeTargetEvent(entity, originalTarget, LivingChangeTargetEvent.LivingTargetType.BEHAVIOR_TARGET);
+        return LivingChangeTargetEvent.BUS.post(event) ? null : event;
     }
 
     public static ItemFishedEvent onPlayerFishedItem(List<ItemStack> stacks, int rodDamage, FishingHook hook) {
-        return fire(new ItemFishedEvent(stacks, rodDamage, hook));
+        return ItemFishedEvent.BUS.fire(new ItemFishedEvent(stacks, rodDamage, hook));
     }
 
     public static PlayerXpEvent.XpChange onPlayerXpChange(Player player, int xp) {
-        return fire(new PlayerXpEvent.XpChange(player, xp));
+        var event = new PlayerXpEvent.XpChange(player, xp);
+        return PlayerXpEvent.XpChange.BUS.post(event) ? null : event;
     }
 
     public static PlayerXpEvent.LevelChange onPlayerLevelChange(Player player, int levels) {
-        return fire(new PlayerXpEvent.LevelChange(player, levels));
+        var event = new PlayerXpEvent.LevelChange(player, levels);
+        return PlayerXpEvent.LevelChange.BUS.post(event) ? null : event;
     }
 
 
     public static GrindstoneEvent.OnPlaceItem onGrindstoneChange(@NotNull ItemStack top, @NotNull ItemStack bottom, Container outputSlot, int xp) {
-        return fire(new GrindstoneEvent.OnPlaceItem(top, bottom, xp));
+        var event = new GrindstoneEvent.OnPlaceItem(top, bottom, xp);
+        return GrindstoneEvent.OnPlaceItem.BUS.post(event) ? null : event;
     }
 
     public static void onBrewingRecipeRegister(Builder builder, FeatureFlagSet features) {
-        fire(new BrewingRecipeRegisterEvent(builder, features));
+        BrewingRecipeRegisterEvent.BUS.fire(new BrewingRecipeRegisterEvent(builder, features));
     }
 
     public static boolean onItemStackedOn(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess) {
-        return post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess));
+        return ItemStackedOnOtherEvent.BUS.post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess));
     }
 
     public static NoteBlockEvent.Play onNotePlay(Level world, BlockPos pos, BlockState state, int note, NoteBlockInstrument instrument) {
-        return fire(new NoteBlockEvent.Play(world, pos, state, note, instrument));
+        var event = new NoteBlockEvent.Play(world, pos, state, note, instrument);
+        return NoteBlockEvent.Play.BUS.post(event) ? null : event;
     }
 
     public static AnvilRepairEvent onAnvilRepair(Player player, @NotNull ItemStack output, @NotNull ItemStack left, @NotNull ItemStack right) {
-        return fire(new AnvilRepairEvent(player, left, right, output));
+        return AnvilRepairEvent.BUS.fire(new AnvilRepairEvent(player, left, right, output));
     }
 
     public static void onPlayerTradeWithVillager(Player player, MerchantOffer offer, AbstractVillager villager) {
-        post(new TradeWithVillagerEvent(player, offer, villager));
+        TradeWithVillagerEvent.BUS.post(new TradeWithVillagerEvent(player, offer, villager));
     }
 
     public static GatherComponentsEvent.Item gatherItemComponentsEvent(Item item, DataComponentMap dataComponents) {
-        return fire(new GatherComponentsEvent.Item(item, dataComponents));
+        return GatherComponentsEvent.Item.BUS.fire(new GatherComponentsEvent.Item(item, dataComponents));
     }
 
     public static LootingLevelEvent fireLootingLevel(LivingEntity target, @Nullable DamageSource cause, int level) {
-        return fire(new LootingLevelEvent(target, cause, level));
+        return LootingLevelEvent.BUS.fire(new LootingLevelEvent(target, cause, level));
     }
 
     public static boolean fireFarmlandTrampleEvent(ServerLevel level, BlockPos pos, BlockState state, float fallDistance, Entity entity) {
-        return post(new BlockEvent.FarmlandTrampleEvent(level, pos, state, fallDistance, entity));
+        return BlockEvent.FarmlandTrampleEvent.BUS.post(new BlockEvent.FarmlandTrampleEvent(level, pos, state, fallDistance, entity));
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -20,7 +20,9 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
+import net.minecraftforge.common.capabilities.CapabilityProvider;
 import net.minecraftforge.common.util.Result;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
@@ -568,23 +570,6 @@ public final class ForgeEventFactory {
 
     public static void onPlayerBrewedPotion(Player player, ItemStack stack) {
         PlayerBrewedPotionEvent.BUS.post(new PlayerBrewedPotionEvent(player, stack));
-    }
-
-    @Nullable
-    public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider) {
-        return gatherCapabilities(type, provider, null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Nullable
-    public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider, @Nullable ICapabilityProvider parent) {
-        return gatherCapabilities(AttachCapabilitiesEvent.create(type, provider), parent);
-    }
-
-    @Nullable
-    private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent) {
-        event.post();
-        return !event.getCapabilities().isEmpty() || parent != null ? new CapabilityDispatcher(event.getCapabilities(), event.getListeners(), parent) : null;
     }
 
     public static boolean fireSleepingLocationCheck(LivingEntity player, BlockPos sleepingLocation) {

--- a/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
+++ b/src/main/java/net/minecraftforge/event/GameShuttingDownEvent.java
@@ -5,7 +5,8 @@
 
 package net.minecraftforge.event;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * A simple marker event that notifies when the game is about to close.
@@ -17,7 +18,8 @@ import net.minecraftforge.eventbus.api.Event;
  *
  * @author Curle
  */
-public class GameShuttingDownEvent extends Event
-{
+public class GameShuttingDownEvent extends MutableEvent {
+    public static final EventBus<GameShuttingDownEvent> BUS = EventBus.create(GameShuttingDownEvent.class);
+
     public GameShuttingDownEvent() {}
 }

--- a/src/main/java/net/minecraftforge/event/GatherComponentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/GatherComponentsEvent.java
@@ -7,9 +7,8 @@ package net.minecraftforge.event;
 
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.item.Item;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nullable;
@@ -18,7 +17,9 @@ import javax.annotation.Nullable;
  Where all the events fore Gathering Components will exist.
  */
 
-public abstract class GatherComponentsEvent extends Event {
+public abstract class GatherComponentsEvent extends MutableEvent {
+    public static final EventBus<GatherComponentsEvent> BUS = EventBus.create(GatherComponentsEvent.class);
+
     private final DataComponentMap.Builder components = DataComponentMap.builder();
     private final DataComponentMap originalComponents;
     private final Object owner;
@@ -55,6 +56,8 @@ public abstract class GatherComponentsEvent extends Event {
      * References in {@link net.minecraft.world.item.Items} may not be valid at the current time.
      */
     public static class Item extends GatherComponentsEvent {
+        public static final EventBus<Item> BUS = EventBus.create(Item.class);
+
         public Item(net.minecraft.world.item.Item item, DataComponentMap dataComponents) {
             super(item, dataComponents);
         }

--- a/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/GrindstoneEvent.java
@@ -8,11 +8,14 @@ package net.minecraftforge.event;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.GrindstoneMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
-public abstract class GrindstoneEvent extends Event
-{
+public abstract class GrindstoneEvent extends MutableEvent {
+    public static final EventBus<GrindstoneEvent> BUS = EventBus.create(GrindstoneEvent.class);
+
     private final ItemStack top;
     private final ItemStack bottom;
     private int xp;
@@ -78,9 +81,9 @@ public abstract class GrindstoneEvent extends Event
      *     </ul>
      * </ul>
      */
-    @Cancelable
-    public static class OnPlaceItem extends GrindstoneEvent
-    {
+    public static class OnPlaceItem extends GrindstoneEvent implements Cancellable {
+        public static final CancellableEventBus<OnPlaceItem> BUS = CancellableEventBus.create(OnPlaceItem.class);
+
         private ItemStack output;
 
         public OnPlaceItem(ItemStack top, ItemStack bottom, int xp)
@@ -118,9 +121,9 @@ public abstract class GrindstoneEvent extends Event
      * If the event is canceled, vanilla behavior will not run, and no inputs will be consumed. <br>
      * if the amount of experience is larger than or equal 0, the vanilla behavior for calculating experience will not run. <br>
      */
-    @Cancelable
-    public static class OnTakeItem extends GrindstoneEvent
-    {
+    public static class OnTakeItem extends GrindstoneEvent implements Cancellable {
+        public static final CancellableEventBus<OnTakeItem> BUS = CancellableEventBus.create(OnTakeItem.class);
+
         private ItemStack newTop = ItemStack.EMPTY;
         private ItemStack newBottom = ItemStack.EMPTY;
 

--- a/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemStackedOnOtherEvent.java
@@ -12,8 +12,9 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -33,9 +34,9 @@ import org.jetbrains.annotations.ApiStatus;
  *  If the event is cancelled, the container's logic halts, the carried item and the slot will not be swapped, and handling is assumed to have been done by the mod.
  *  This also means that the two vanilla checks described above will not be called.
  */
-@Cancelable
-public class ItemStackedOnOtherEvent extends Event
-{
+public class ItemStackedOnOtherEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ItemStackedOnOtherEvent> BUS = CancellableEventBus.create(ItemStackedOnOtherEvent.class);
+
     private final ItemStack carriedItem;
     private final ItemStack stackedOnItem;
     private final Slot slot;

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -8,8 +8,9 @@ package net.minecraftforge.event;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -23,9 +24,9 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
-@Cancelable
-public class LootTableLoadEvent extends Event
-{
+public class LootTableLoadEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<LootTableLoadEvent> BUS = CancellableEventBus.create(LootTableLoadEvent.class);
+
     private final ResourceLocation name;
     private LootTable table;
 

--- a/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.event;
 
 import net.minecraft.world.level.storage.LevelStorageSource;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModContainer;
@@ -39,7 +41,9 @@ import java.util.stream.Stream;
  * on both {@linkplain LogicalSide logical sides}.</p>
  */
 public class ModMismatchEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<ModMismatchEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, ModMismatchEvent.class);
+    }
 
     /**
      * The level being loaded. Useful for things like {@link net.minecraft.world.level.storage.DimensionDataStorage}

--- a/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
@@ -6,8 +6,7 @@
 package net.minecraftforge.event;
 
 import net.minecraft.world.level.storage.LevelStorageSource;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModList;
@@ -39,8 +38,9 @@ import java.util.stream.Stream;
  * <p>This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
  * on both {@linkplain LogicalSide logical sides}.</p>
  */
-public class ModMismatchEvent extends Event implements IModBusEvent
-{
+public class ModMismatchEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     /**
      * The level being loaded. Useful for things like {@link net.minecraft.world.level.storage.DimensionDataStorage}
      * to manage multiple files changing between mod versions.

--- a/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/minecraftforge/event/OnDatapackSyncEvent.java
@@ -7,7 +7,8 @@ package net.minecraftforge.event;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -17,7 +18,9 @@ import java.util.List;
  * before tags and crafting recipes are sent to the client. Send datapack data
  * to clients when this event fires.
  */
-public class OnDatapackSyncEvent extends Event {
+public class OnDatapackSyncEvent extends MutableEvent {
+    public static final EventBus<OnDatapackSyncEvent> BUS = EventBus.create(OnDatapackSyncEvent.class);
+
     private final PlayerList playerList;
 
     @Nullable

--- a/src/main/java/net/minecraftforge/event/PlayLevelSoundEvent.java
+++ b/src/main/java/net/minecraftforge/event/PlayLevelSoundEvent.java
@@ -13,8 +13,9 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
@@ -37,8 +38,9 @@ import java.util.Objects;
  * <p>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@Cancelable
-public class PlayLevelSoundEvent extends Event {
+public class PlayLevelSoundEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<PlayLevelSoundEvent> BUS = CancellableEventBus.create(PlayLevelSoundEvent.class);
+
     private final Level level;
     private final float originalVolume;
     private final float originalPitch;
@@ -149,7 +151,9 @@ public class PlayLevelSoundEvent extends Event {
      * <p>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      */
-    public static class AtEntity extends PlayLevelSoundEvent {
+    public static class AtEntity extends PlayLevelSoundEvent implements Cancellable {
+        public static final CancellableEventBus<AtEntity> BUS = CancellableEventBus.create(AtEntity.class);
+
         private final Entity entity;
 
         public AtEntity(Entity entity, Holder<SoundEvent> sound, SoundSource source, float volume, float pitch) {
@@ -176,7 +180,9 @@ public class PlayLevelSoundEvent extends Event {
      * <p>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      */
-    public static class AtPosition extends PlayLevelSoundEvent {
+    public static class AtPosition extends PlayLevelSoundEvent implements Cancellable {
+        public static final CancellableEventBus<AtPosition> BUS = CancellableEventBus.create(AtPosition.class);
+
         private final Vec3 position;
 
         public AtPosition(Level level, Vec3 position, Holder<SoundEvent> sound, SoundSource source, float volume, float pitch) {

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -9,11 +9,11 @@ import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
-
 
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * Commands are rebuilt whenever {@link ReloadableServerResources} is recreated.
@@ -21,8 +21,9 @@ import net.minecraft.commands.Commands;
  *
  * The event is fired on the {@link MinecraftForge#EVENT_BUS}
  */
-public class RegisterCommandsEvent extends Event
-{
+public class RegisterCommandsEvent extends MutableEvent {
+    public static final EventBus<RegisterCommandsEvent> BUS = EventBus.create(RegisterCommandsEvent.class);
+
     private final CommandDispatcher<CommandSourceStack> dispatcher;
     private final Commands.CommandSelection environment;
     private final CommandBuildContext context;

--- a/src/main/java/net/minecraftforge/event/RegisterGameTestsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterGameTestsEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.event;
 
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestGenerator;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.gametest.ForgeGameTestHooks;
@@ -23,7 +25,9 @@ import java.util.Set;
  * Fired on the Mod bus, see {@link IModBusEvent}.
  */
 public class RegisterGameTestsEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterGameTestsEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterGameTestsEvent.class);
+    }
 
     private final Set<Method> gameTestMethods;
 

--- a/src/main/java/net/minecraftforge/event/RegisterGameTestsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterGameTestsEvent.java
@@ -7,7 +7,7 @@ package net.minecraftforge.event;
 
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestGenerator;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.gametest.ForgeGameTestHooks;
 
@@ -22,7 +22,9 @@ import java.util.Set;
  * <p>
  * Fired on the Mod bus, see {@link IModBusEvent}.
  */
-public class RegisterGameTestsEvent extends Event implements IModBusEvent {
+public class RegisterGameTestsEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private final Set<Method> gameTestMethods;
 
     public RegisterGameTestsEvent(Set<Method> gameTestMethods) {

--- a/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterStructureConversionsEvent.java
@@ -8,13 +8,13 @@ package net.minecraftforge.event;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 import java.util.Locale;
 import java.util.Map;
 
 import com.google.common.base.Preconditions;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * Fired for registering structure conversions for pre-1.18.2 worlds. This is used by {@link StructuresBecomeConfiguredFix}
@@ -35,8 +35,9 @@ import com.google.common.base.Preconditions;
  * @see StructuresBecomeConfiguredFix
  * @see #register(String, StructuresBecomeConfiguredFix.Conversion)
  */
-public class RegisterStructureConversionsEvent extends Event
-{
+public class RegisterStructureConversionsEvent extends MutableEvent {
+    public static final EventBus<RegisterStructureConversionsEvent> BUS = EventBus.create(RegisterStructureConversionsEvent.class);
+
     private final Map<String, StructuresBecomeConfiguredFix.Conversion> map;
 
     /**

--- a/src/main/java/net/minecraftforge/event/ServerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerChatEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundChatPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -25,8 +26,9 @@ import org.jetbrains.annotations.ApiStatus;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-@Cancelable
-public class ServerChatEvent extends Event {
+public class ServerChatEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<ServerChatEvent> BUS = CancellableEventBus.create(ServerChatEvent.class);
+
     private final ServerPlayer player;
     private final String username;
     private final String rawText;

--- a/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
@@ -6,13 +6,15 @@
 package net.minecraftforge.event;
 
 import net.minecraft.core.RegistryAccess;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
  */
-public class TagsUpdatedEvent extends Event
-{
+public class TagsUpdatedEvent extends MutableEvent {
+    public static final EventBus<TagsUpdatedEvent> BUS = EventBus.create(TagsUpdatedEvent.class);
+
     private final RegistryAccess registryAccess;
     private final UpdateCause updateCause;
     private final boolean integratedServer;

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -13,10 +13,13 @@ import java.util.function.BooleanSupplier;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 
-public class TickEvent extends Event {
+public class TickEvent extends MutableEvent {
+    public static final EventBus<TickEvent> BUS = EventBus.create(TickEvent.class);
+
     public enum Type {
         LEVEL, PLAYER, CLIENT, SERVER, RENDER;
     }
@@ -36,6 +39,8 @@ public class TickEvent extends Event {
     }
 
     public static class ServerTickEvent extends TickEvent {
+        public static final EventBus<ServerTickEvent> BUS = EventBus.create(ServerTickEvent.class);
+
         private final BooleanSupplier haveTime;
         private final MinecraftServer server;
 
@@ -62,12 +67,16 @@ public class TickEvent extends Event {
         }
 
         public static class Pre extends ServerTickEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre(BooleanSupplier haveTime, MinecraftServer server) {
                 super(haveTime, server, Phase.START);
             }
         }
 
         public static class Post extends ServerTickEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             public Post(BooleanSupplier haveTime, MinecraftServer server) {
                 super(haveTime, server, Phase.END);
             }
@@ -75,17 +84,23 @@ public class TickEvent extends Event {
     }
 
     public static class ClientTickEvent extends TickEvent {
+        public static final EventBus<ClientTickEvent> BUS = EventBus.create(ClientTickEvent.class);
+
         protected ClientTickEvent(Phase phase) {
             super(Type.CLIENT, LogicalSide.CLIENT, phase);
         }
 
         public static class Pre extends ClientTickEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre() {
                 super(Phase.START);
             }
         }
 
         public static class Post extends ClientTickEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             public Post() {
                 super(Phase.END);
             }
@@ -93,6 +108,8 @@ public class TickEvent extends Event {
     }
 
     public static class LevelTickEvent extends TickEvent {
+        public static final EventBus<LevelTickEvent> BUS = EventBus.create(LevelTickEvent.class);
+
         public final Level level;
         private final BooleanSupplier haveTime;
 
@@ -113,12 +130,16 @@ public class TickEvent extends Event {
         }
 
         public static class Pre extends LevelTickEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre(LogicalSide side, Level level, BooleanSupplier haveTime) {
                 super(side, level, haveTime, Phase.START);
             }
         }
 
         public static class Post extends LevelTickEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             public Post(LogicalSide side, Level level, BooleanSupplier haveTime) {
                 super(side, level, haveTime, Phase.END);
             }
@@ -126,6 +147,8 @@ public class TickEvent extends Event {
     }
 
     public static class PlayerTickEvent extends TickEvent {
+        public static final EventBus<PlayerTickEvent> BUS = EventBus.create(PlayerTickEvent.class);
+
         public final Player player;
 
         protected PlayerTickEvent(Player player, Phase phase) {
@@ -134,12 +157,16 @@ public class TickEvent extends Event {
         }
 
         public static class Pre extends PlayerTickEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre(Player player) {
                 super(player, Phase.START);
             }
         }
 
         public static class Post extends PlayerTickEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             public Post(Player player) {
                 super(player, Phase.END);
             }
@@ -147,6 +174,8 @@ public class TickEvent extends Event {
     }
 
     public static class RenderTickEvent extends TickEvent {
+        public static final EventBus<RenderTickEvent> BUS = EventBus.create(RenderTickEvent.class);
+
         private final DeltaTracker timer;
 
         private RenderTickEvent(Phase phase, DeltaTracker timer) {
@@ -159,12 +188,16 @@ public class TickEvent extends Event {
         }
 
         public static class Pre extends RenderTickEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre(DeltaTracker timer) {
                 super(Phase.START, timer);
             }
         }
 
         public static class Post extends RenderTickEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             public Post(DeltaTracker timer) {
                 super(Phase.END, timer);
             }

--- a/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
+++ b/src/main/java/net/minecraftforge/event/VanillaGameEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -23,9 +24,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * Cancel this event to prevent Vanilla from posting the {@link GameEvent} to all nearby {@link net.minecraft.world.level.gameevent.GameEventListener GameEventListeners}.
  **/
-@Cancelable
-public class VanillaGameEvent extends Event
-{
+public class VanillaGameEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<VanillaGameEvent> BUS = CancellableEventBus.create(VanillaGameEvent.class);
+
     private final Level level;
     private final GameEvent vanillaEvent;
     private final Vec3 position;

--- a/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
@@ -17,7 +17,7 @@ import net.minecraftforge.common.brewing.BrewingRecipe;
 import net.minecraftforge.common.brewing.IBrewingRecipe;
 
 public class BrewingRecipeRegisterEvent extends MutableEvent {
-    private static final EventBus<BrewingRecipeRegisterEvent> BUS = EventBus.create(BrewingRecipeRegisterEvent.class);
+    public static final EventBus<BrewingRecipeRegisterEvent> BUS = EventBus.create(BrewingRecipeRegisterEvent.class);
 
     private final PotionBrewing.Builder builder;
     private final FeatureFlagSet features;

--- a/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/BrewingRecipeRegisterEvent.java
@@ -5,6 +5,8 @@
 
 package net.minecraftforge.event.brewing;
 
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.world.flag.FeatureFlagSet;
@@ -13,9 +15,10 @@ import net.minecraft.world.item.alchemy.PotionBrewing;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.brewing.BrewingRecipe;
 import net.minecraftforge.common.brewing.IBrewingRecipe;
-import net.minecraftforge.eventbus.api.Event;
 
-public class BrewingRecipeRegisterEvent extends Event {
+public class BrewingRecipeRegisterEvent extends MutableEvent {
+    private static final EventBus<BrewingRecipeRegisterEvent> BUS = EventBus.create(BrewingRecipeRegisterEvent.class);
+
     private final PotionBrewing.Builder builder;
     private final FeatureFlagSet features;
 

--- a/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
@@ -8,13 +8,15 @@ package net.minecraftforge.event.brewing;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * This event is called when a player picks up a potion from a brewing stand.
  */
-public class PlayerBrewedPotionEvent extends PlayerEvent
-{
+public class PlayerBrewedPotionEvent extends PlayerEvent {
+    private static final EventBus<PlayerBrewedPotionEvent> BUS = new EventBus<>(PlayerBrewedPotionEvent.class);
+
     private final ItemStack stack;
 
     public PlayerBrewedPotionEvent(Player player, @NotNull ItemStack stack)

--- a/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * This event is called when a player picks up a potion from a brewing stand.
  */
 public class PlayerBrewedPotionEvent extends PlayerEvent {
-    private static final EventBus<PlayerBrewedPotionEvent> BUS = new EventBus<>(PlayerBrewedPotionEvent.class);
+    public static final EventBus<PlayerBrewedPotionEvent> BUS = EventBus.create(PlayerBrewedPotionEvent.class);
 
     private final ItemStack stack;
 

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -8,6 +8,7 @@ package net.minecraftforge.event.brewing;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
@@ -61,6 +62,8 @@ public class PotionBrewEvent extends MutableEvent {
      * If this event is canceled, and items have been modified, PotionBrewEvent.Post will automatically be fired.
      **/
     public static class Pre extends PotionBrewEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
         public Pre(NonNullList<ItemStack> stacks)
         {
             super(stacks);
@@ -81,6 +84,8 @@ public class PotionBrewEvent extends MutableEvent {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
     public static class Post extends PotionBrewEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
         public Post(NonNullList<ItemStack> stacks)
         {
             super(stacks);

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -8,13 +8,15 @@ package net.minecraftforge.event.brewing;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 
-public class PotionBrewEvent extends Event
-{
-    private NonNullList<ItemStack> stacks;
+public class PotionBrewEvent extends MutableEvent {
+    public static final EventBus<PotionBrewEvent> BUS = EventBus.create(PotionBrewEvent.class);
+
+    private final NonNullList<ItemStack> stacks;
 
     protected PotionBrewEvent(NonNullList<ItemStack> stacks)
     {
@@ -58,9 +60,7 @@ public class PotionBrewEvent extends Event
      * <br>
      * If this event is canceled, and items have been modified, PotionBrewEvent.Post will automatically be fired.
      **/
-    @Cancelable
-    public static class Pre extends PotionBrewEvent
-    {
+    public static class Pre extends PotionBrewEvent implements Cancellable {
         public Pre(NonNullList<ItemStack> stacks)
         {
             super(stacks);
@@ -80,8 +80,7 @@ public class PotionBrewEvent extends Event
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Post extends PotionBrewEvent
-    {
+    public static class Post extends PotionBrewEvent {
         public Post(NonNullList<ItemStack> stacks)
         {
             super(stacks);

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.event.enchanting;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -18,8 +20,9 @@ import org.jetbrains.annotations.NotNull;
  * from 0-15 and indicates how many bookshelves surround the enchanting table. The {@link #itemStack} representing the item being
  * enchanted is also available.
  */
-public class EnchantmentLevelSetEvent extends net.minecraftforge.eventbus.api.Event
-{
+public class EnchantmentLevelSetEvent extends MutableEvent {
+    public static final EventBus<EnchantmentLevelSetEvent> BUS = EventBus.create(EnchantmentLevelSetEvent.class);
+
     private final Level level;
     private final BlockPos pos;
     private final int enchantRow;

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
@@ -11,6 +11,8 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 
@@ -22,7 +24,10 @@ import net.minecraftforge.fml.event.IModBusEvent;
  * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
 public class EntityAttributeCreationEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] EntityAttributeCreationEvent.BUS from mod BusGroup
+    public static EventBus<EntityAttributeCreationEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, EntityAttributeCreationEvent.class);
+    }
+
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier> map;
 
     public EntityAttributeCreationEvent(Map<EntityType<? extends LivingEntity>, AttributeSupplier> map) {

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeCreationEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
@@ -21,7 +21,8 @@ import net.minecraftforge.fml.event.IModBusEvent;
  * <br>
  * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
-public class EntityAttributeCreationEvent extends Event implements IModBusEvent {
+public class EntityAttributeCreationEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] EntityAttributeCreationEvent.BUS from mod BusGroup
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier> map;
 
     public EntityAttributeCreationEvent(Map<EntityType<? extends LivingEntity>, AttributeSupplier> map) {

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
@@ -13,7 +13,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -28,7 +28,8 @@ import java.util.stream.Collectors;
  * <br>
  * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
-public class EntityAttributeModificationEvent extends Event implements IModBusEvent {
+public class EntityAttributeModificationEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] EntityAttributeCreationEvent.BUS from mod BusGroup
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> entityAttributes;
     private final List<EntityType<? extends LivingEntity>> entityTypes;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityAttributeModificationEvent.java
@@ -13,6 +13,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -29,7 +31,10 @@ import java.util.stream.Collectors;
  * Fired on the Mod bus {@link IModBusEvent}.<br>
  **/
 public class EntityAttributeModificationEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] EntityAttributeCreationEvent.BUS from mod BusGroup
+    public static EventBus<EntityAttributeModificationEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, EntityAttributeModificationEvent.class);
+    }
+
     private final Map<EntityType<? extends LivingEntity>, AttributeSupplier.Builder> entityAttributes;
     private final List<EntityType<? extends LivingEntity>> entityTypes;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.event.entity;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * EntityEvent is fired when an event involving any Entity occurs.<br>
@@ -19,7 +20,9 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class EntityEvent extends Event {
+public class EntityEvent extends MutableEvent {
+    public static final EventBus<EntityEvent> BUS = EventBus.create(EntityEvent.class);
+
     private final Entity entity;
 
     public EntityEvent(Entity entity) {
@@ -41,6 +44,8 @@ public class EntityEvent extends Event {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
     public static class EntityConstructing extends EntityEvent {
+        public static final EventBus<EntityConstructing> BUS = EventBus.create(EntityConstructing.class);
+
         public EntityConstructing(Entity entity) {
             super(entity);
         }
@@ -59,6 +64,8 @@ public class EntityEvent extends Event {
      * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.<br>
      **/
     public static class EnteringSection extends EntityEvent {
+        public static final EventBus<EnteringSection> BUS = EventBus.create(EnteringSection.class);
+
         private final long packedOldPos;
         private final long packedNewPos;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinLevelEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -26,8 +27,9 @@ import net.minecraftforge.fml.LogicalSide;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * on both logical sides.
  **/
-@Cancelable
-public class EntityJoinLevelEvent extends EntityEvent {
+public class EntityJoinLevelEvent extends EntityEvent implements Cancellable {
+    public static final CancellableEventBus<EntityJoinLevelEvent> BUS = CancellableEventBus.create(EntityJoinLevelEvent.class);
+
     private final Level level;
     private final boolean loadedFromDisk;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityLeaveLevelEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.entity.LevelCallback;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired whenever an {@link Entity} leaves a {@link Level}.
@@ -21,6 +21,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * on both logical sides.
  **/
 public class EntityLeaveLevelEvent extends EntityEvent {
+    public static final EventBus<EntityLeaveLevelEvent> BUS = EventBus.create(EntityLeaveLevelEvent.class);
+
     private final Level level;
 
     public EntityLeaveLevelEvent(Entity entity, Level level) {

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
@@ -21,12 +23,22 @@ import net.minecraftforge.eventbus.api.bus.EventBus;
  * </ul>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@HasResult
-public class EntityMobGriefingEvent extends EntityEvent {
+public class EntityMobGriefingEvent extends EntityEvent implements HasResult {
     public static final EventBus<EntityMobGriefingEvent> BUS = EventBus.create(EntityMobGriefingEvent.class);
 
-    public EntityMobGriefingEvent(Entity entity)
-    {
+    private Result result = Result.DEFAULT;
+
+    public EntityMobGriefingEvent(Entity entity) {
         super(entity);
+    }
+
+    @Override
+    public Result getResult() {
+        return this.result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -7,7 +7,7 @@ package net.minecraftforge.event.entity;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * EntityMobGriefingEvent is fired when mob griefing is about to occur and allows an event listener to specify whether it should or not.<br>
@@ -22,8 +22,9 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 @HasResult
-public class EntityMobGriefingEvent extends EntityEvent
-{
+public class EntityMobGriefingEvent extends EntityEvent {
+    public static final EventBus<EntityMobGriefingEvent> BUS = EventBus.create(EntityMobGriefingEvent.class);
+
     public EntityMobGriefingEvent(Entity entity)
     {
         super(entity);

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.event.entity;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event gets fired whenever a entity mounts/dismounts another entity.<br>
@@ -23,10 +24,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  *
  */
-
-@Cancelable
-public class EntityMountEvent extends EntityEvent
-{
+public class EntityMountEvent extends EntityEvent implements Cancellable {
+    public static final CancellableEventBus<EntityMountEvent> BUS = CancellableEventBus.create(EntityMountEvent.class);
 
     private final Entity entityMounting;
     private final Entity entityBeingMounted;

--- a/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * EntityStruckByLightningEvent is fired when an Entity is about to be struck by lightening.<br>
@@ -25,9 +26,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-@net.minecraftforge.eventbus.api.Cancelable
-public class EntityStruckByLightningEvent extends EntityEvent
-{
+public class EntityStruckByLightningEvent extends EntityEvent implements Cancellable {
+    public static final CancellableEventBus<EntityStruckByLightningEvent> BUS = CancellableEventBus.create(EntityStruckByLightningEvent.class);
+
     private final LightningBolt lightning;
 
     public EntityStruckByLightningEvent(Entity entity, LightningBolt lightning)

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -12,8 +12,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -28,9 +28,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-@Cancelable
-public class EntityTeleportEvent extends EntityEvent
-{
+public class EntityTeleportEvent extends EntityEvent implements Cancellable {
+    public static final CancellableEventBus<EntityTeleportEvent> BUS = CancellableEventBus.create(EntityTeleportEvent.class);
+
     protected double targetX;
     protected double targetY;
     protected double targetZ;
@@ -69,9 +69,9 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class TeleportCommand extends EntityTeleportEvent
-    {
+    public static class TeleportCommand extends EntityTeleportEvent implements Cancellable {
+        public static final CancellableEventBus<TeleportCommand> BUS = CancellableEventBus.create(TeleportCommand.class);
+
         public TeleportCommand(Entity entity, double targetX, double targetY, double targetZ)
         {
             super(entity, targetX, targetY, targetZ);
@@ -93,9 +93,9 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class SpreadPlayersCommand extends EntityTeleportEvent
-    {
+    public static class SpreadPlayersCommand extends EntityTeleportEvent implements Cancellable {
+        public static final CancellableEventBus<SpreadPlayersCommand> BUS = CancellableEventBus.create(SpreadPlayersCommand.class);
+
         public SpreadPlayersCommand(Entity entity, double targetX, double targetY, double targetZ)
         {
             super(entity, targetX, targetY, targetZ);
@@ -116,9 +116,9 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class EnderEntity extends EntityTeleportEvent
-    {
+    public static class EnderEntity extends EntityTeleportEvent implements Cancellable {
+        public static final CancellableEventBus<EnderEntity> BUS = CancellableEventBus.create(EnderEntity.class);
+
         private final LivingEntity entityLiving;
 
         public EnderEntity(LivingEntity entity, double targetX, double targetY, double targetZ)
@@ -147,9 +147,9 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class EnderPearl extends EntityTeleportEvent
-    {
+    public static class EnderPearl extends EntityTeleportEvent implements Cancellable {
+        public static final CancellableEventBus<EnderPearl> BUS = CancellableEventBus.create(EnderPearl.class);
+
         private final ServerPlayer player;
         private final ThrownEnderpearl pearlEntity;
         private float attackDamage;
@@ -206,9 +206,9 @@ public class EntityTeleportEvent extends EntityEvent
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    @Cancelable
-    public static class ChorusFruit extends EntityTeleportEvent
-    {
+    public static class ChorusFruit extends EntityTeleportEvent implements Cancellable {
+        public static final CancellableEventBus<ChorusFruit> BUS = CancellableEventBus.create(ChorusFruit.class);
+
         private final LivingEntity entityLiving;
 
         public ChorusFruit(LivingEntity entity, double targetX, double targetY, double targetZ)

--- a/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTeleportEvent.java
@@ -12,6 +12,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
@@ -116,7 +117,7 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    public static class EnderEntity extends EntityTeleportEvent implements Cancellable {
+    public static class EnderEntity extends EntityTeleportEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<EnderEntity> BUS = CancellableEventBus.create(EnderEntity.class);
 
         private final LivingEntity entityLiving;
@@ -147,7 +148,7 @@ public class EntityTeleportEvent extends EntityEvent implements Cancellable {
      * <br>
      * If this event is canceled, the entity will not be teleported.
      */
-    public static class EnderPearl extends EntityTeleportEvent implements Cancellable {
+    public static class EnderPearl extends EntityTeleportEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<EnderPearl> BUS = CancellableEventBus.create(EnderPearl.class);
 
         private final ServerPlayer player;

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * EntityTravelToDimensionEvent is fired before an Entity travels to a dimension.<br>
@@ -23,9 +24,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-@Cancelable
-public class EntityTravelToDimensionEvent extends EntityEvent
-{
+public class EntityTravelToDimensionEvent extends EntityEvent implements Cancellable {
+    public static final CancellableEventBus<EntityTravelToDimensionEvent> BUS = CancellableEventBus.create(EntityTravelToDimensionEvent.class);
+
     private final ResourceKey<Level> dimension;
 
     public EntityTravelToDimensionEvent(Entity entity, ResourceKey<Level> dimension)

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -23,6 +24,8 @@ import java.util.Objects;
  * @see #setImpactResult(ImpactResult)
  */
 public class ProjectileImpactEvent extends EntityEvent {
+    public static final EventBus<ProjectileImpactEvent> BUS = EventBus.create(ProjectileImpactEvent.class);
+
     private final HitResult ray;
     private final Projectile projectile;
 

--- a/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -16,6 +16,9 @@ import net.minecraft.world.entity.SpawnPlacementType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -42,7 +45,10 @@ import org.jetbrains.annotations.ApiStatus;
  *  Fired on the Mod bus {@link IModBusEvent}.<br>
  */
 public class SpawnPlacementRegisterEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] SpawnPlacementRegisterEvent.BUS from mod BusGroup
+    public static EventBus<SpawnPlacementRegisterEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, SpawnPlacementRegisterEvent.class);
+    }
+
     private final Map<EntityType<?>, MergedSpawnPredicate<?>> map;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -16,7 +16,7 @@ import net.minecraft.world.entity.SpawnPlacementType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.level.levelgen.Heightmap;
-import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.ApiStatus;
  * So that you ensure that your entity has a heightmap type and placement type registered.
  *
  * If modifying vanilla or another mod's spawn placements, you can use three operations:
- *  REPLACE: checked first, the last mod to replace the predicate wipes out all other predicates. Listen with a low {@link EventPriority} if you need to do this.
+ *  REPLACE: checked first, the last mod to replace the predicate wipes out all other predicates. Listen with a low {@link Priority} if you need to do this.
  *  OR: checked second, only one of these predicates must pass along with the original predicate
  *  AND: checked third, these predicates must all pass along with the original predicate
  *

--- a/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -16,9 +16,8 @@ import net.minecraft.world.entity.SpawnPlacementType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.level.levelgen.Heightmap;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -42,7 +41,8 @@ import org.jetbrains.annotations.ApiStatus;
  *
  *  Fired on the Mod bus {@link IModBusEvent}.<br>
  */
-public class SpawnPlacementRegisterEvent extends Event implements IModBusEvent {
+public class SpawnPlacementRegisterEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] SpawnPlacementRegisterEvent.BUS from mod BusGroup
     private final Map<EntityType<?>, MergedSpawnPredicate<?>> map;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity.item;
 
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Base class for all {@link ItemEntity} events. Contains a reference to the
@@ -14,8 +15,9 @@ import net.minecraftforge.event.entity.EntityEvent;
  * additional useful data from the firing method that isn't already contained
  * within the ItemEntity instance.
  */
-public class ItemEvent extends EntityEvent
-{
+public class ItemEvent extends EntityEvent {
+    public static final EventBus<ItemEvent> BUS = EventBus.create(ItemEvent.class);
+
     private final ItemEntity itemEntity;
 
     /**

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
@@ -5,8 +5,9 @@
 
 package net.minecraftforge.event.entity.item;
 
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Event that is fired when an EntityItem's age has reached its maximum
@@ -14,9 +15,8 @@ import net.minecraft.world.entity.item.ItemEntity;
  * flagged as dead, thus staying it's removal from the world. If canceled
  * it will add more time to the entities life equal to extraLife.
  */
-@Cancelable
-public class ItemExpireEvent extends ItemEvent
-{
+public class ItemExpireEvent extends ItemEvent implements Cancellable {
+    public static final CancellableEventBus<ItemExpireEvent> BUS = CancellableEventBus.create(ItemExpireEvent.class);
 
     private int extraLife;
 

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
@@ -5,9 +5,10 @@
 
 package net.minecraftforge.event.entity.item;
 
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Event that is fired whenever a player tosses (Q) an item or drag-n-drops a
@@ -15,9 +16,8 @@ import net.minecraft.world.entity.player.Player;
  * stop the items from entering the world, but will not prevent them being
  * removed from the inventory - and thus removed from the system.
  */
-@Cancelable
-public class ItemTossEvent extends ItemEvent
-{
+public class ItemTossEvent extends ItemEvent implements Cancellable {
+    public static final CancellableEventBus<ItemTossEvent> BUS = CancellableEventBus.create(ItemTossEvent.class);
 
     private final Player player;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event is fired when an {@link Animal} is tamed. <br>
@@ -18,9 +19,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is {@link net.minecraftforge.eventbus.api.Cancelable}. If canceled, taming the animal will fail.
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@Cancelable
-public class AnimalTameEvent extends LivingEvent
-{
+public class AnimalTameEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<AnimalTameEvent> BUS = CancellableEventBus.create(AnimalTameEvent.class);
+
     private final Animal animal;
     private final Player tamer;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.animal.Fox;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
@@ -38,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class BabyEntitySpawnEvent extends MutableEvent implements Cancellable {
+public class BabyEntitySpawnEvent extends MutableEvent implements Cancellable, CancellableAware {
     public static final CancellableEventBus<BabyEntitySpawnEvent> BUS = CancellableEventBus.create(BabyEntitySpawnEvent.class);
 
     private final Mob parentA;

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -12,9 +12,10 @@ import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.animal.Fox;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -37,8 +38,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class BabyEntitySpawnEvent extends Event {
+public class BabyEntitySpawnEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<BabyEntitySpawnEvent> BUS = CancellableEventBus.create(BabyEntitySpawnEvent.class);
+
     private final Mob parentA;
     private final Mob parentB;
     private final Player causedByPlayer;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -8,9 +8,10 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingAttackEvent is fired when a living Entity is attacked. <br>
@@ -30,9 +31,9 @@ import net.minecraft.world.entity.LivingEntity;
  *<br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingAttackEvent extends LivingEvent
-{
+public class LivingAttackEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingAttackEvent> BUS = CancellableEventBus.create(LivingAttackEvent.class);
+
     private final DamageSource source;
     private final float amount;
     public LivingAttackEvent(LivingEntity entity, DamageSource source, float amount)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingBreatheEvent.java
@@ -5,12 +5,12 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingBreatheEvent is fired whenever a living entity ticks.<br>
@@ -24,6 +24,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  */
 public class LivingBreatheEvent extends LivingEvent {
+    public static final EventBus<LivingBreatheEvent> BUS = EventBus.create(LivingBreatheEvent.class);
+
     private boolean canBreathe;
     private boolean canRefillAir;
     private int consumeAirAmount;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingChangeTargetEvent.java
@@ -10,7 +10,8 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.behavior.StartAttacking;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event allows you to change the target an entity has. <br>
@@ -33,8 +34,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@Cancelable
-public class LivingChangeTargetEvent extends LivingEvent {
+public class LivingChangeTargetEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingChangeTargetEvent> BUS = CancellableEventBus.create(LivingChangeTargetEvent.class);
+
     private final ILivingTargetType targetType;
     private final LivingEntity originalTarget;
     private LivingEntity newTarget;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingConversionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingConversionEvent.java
@@ -7,7 +7,9 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 import java.util.function.Consumer;
 
@@ -26,6 +28,8 @@ import java.util.function.Consumer;
  *   Mushroom Cow -> Cow when sheared
  */
 public class LivingConversionEvent extends LivingEvent {
+    public static final EventBus<LivingConversionEvent> BUS = EventBus.create(LivingConversionEvent.class);
+
     public LivingConversionEvent(LivingEntity entity) {
         super(entity);
     }
@@ -41,8 +45,9 @@ public class LivingConversionEvent extends LivingEvent {
      * This event is {@link Cancelable}
      * If cancelled, the replacement will not occur
      */
-    @Cancelable
-    public static class Pre extends LivingConversionEvent {
+    public static class Pre extends LivingConversionEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
+
         private final EntityType<? extends LivingEntity> outcome;
         private final Consumer<Integer> timer;
 
@@ -80,6 +85,8 @@ public class LivingConversionEvent extends LivingEvent {
      * The old living entity is likely to be removed right after this event.
      */
     public static class Post extends LivingConversionEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
         private final LivingEntity outcome;
 
         public Post(LivingEntity entity, LivingEntity outcome) {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -6,9 +6,10 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingDamageEvent is fired just before damage is applied to entity.<br>
@@ -29,9 +30,9 @@ import net.minecraft.world.entity.LivingEntity;
  * This event does not have a result. {@link HasResult}<br>
  * @see LivingHurtEvent
  **/
-@Cancelable
-public class LivingDamageEvent extends LivingEvent
-{
+public class LivingDamageEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingDamageEvent> BUS = CancellableEventBus.create(LivingDamageEvent.class);
+
     private final DamageSource source;
     private float amount;
     public LivingDamageEvent(LivingEntity entity, DamageSource source, float amount)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
@@ -9,9 +9,10 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingDeathEvent is fired when an Entity dies. <br>
@@ -31,9 +32,9 @@ import net.minecraft.world.entity.LivingEntity;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingDeathEvent extends LivingEvent
-{
+public class LivingDeathEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingDeathEvent> BUS = CancellableEventBus.create(LivingDeathEvent.class);
+
     private final DamageSource source;
     public LivingDeathEvent(LivingEntity entity, DamageSource source)
     {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -12,7 +12,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link Block#canEntityDestroy(BlockState, BlockGetter, BlockPos, Entity)}<br>
@@ -24,9 +25,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingDestroyBlockEvent extends LivingEvent
-{
+public class LivingDestroyBlockEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingDestroyBlockEvent> BUS = CancellableEventBus.create(LivingDestroyBlockEvent.class);
+
     private final BlockPos pos;
     private final BlockState state;
     

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
@@ -12,7 +12,8 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingDropsEvent is fired when an Entity's death causes dropped items to appear.<br>
@@ -33,8 +34,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@net.minecraftforge.eventbus.api.Cancelable
-public class LivingDropsEvent extends LivingEvent {
+public class LivingDropsEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingDropsEvent> BUS = CancellableEventBus.create(LivingDropsEvent.class);
+
     private final DamageSource source;
     private final Collection<ItemEntity> drops;
     private final boolean recentlyHit;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.ApiStatus;
@@ -26,7 +27,7 @@ import net.minecraftforge.common.MinecraftForge;
  * This event does not {@linkplain HasResult have a result}.
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  **/
-public class LivingDrownEvent extends LivingEvent implements Cancellable {
+public class LivingDrownEvent extends LivingEvent implements Cancellable, CancellableAware {
     public static final CancellableEventBus<LivingDrownEvent> BUS = CancellableEventBus.create(LivingDrownEvent.class);
 
     private boolean isDrowning;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDrownEvent.java
@@ -5,6 +5,8 @@
 
 package net.minecraftforge.event.entity.living;
 
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.core.particles.ParticleTypes;
@@ -13,7 +15,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
  * LivingDrownEvent is fired whenever a living entity can't breathe and its air supply is less than or equal to zero.
@@ -25,8 +26,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event does not {@linkplain HasResult have a result}.
  * This event is fired on {@link MinecraftForge#EVENT_BUS}
  **/
-@Cancelable
-public class LivingDrownEvent extends LivingEvent {
+public class LivingDrownEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingDrownEvent> BUS = CancellableEventBus.create(LivingDrownEvent.class);
+
     private boolean isDrowning;
     private float damageAmount;
     private int bubbleCount;
@@ -112,13 +114,14 @@ public class LivingDrownEvent extends LivingEvent {
         this.bubbleCount = bubbleCount;
     }
 
-    /**
-     * Cancels the drowning event.<br>
-     * Cancellation is mostly equivalent to {@link #setDrowning(boolean)} with a value of false.<br>
-     * However, this also incurs the usual side effects of cancellation.
-     */
-    @Override
-    public void setCanceled(boolean cancel) {
-        super.setCanceled(cancel);
-    }
+    // Todo: [Forge][Event] LivingDownEvent#setCanceled(boolean) override for javadoc
+//    /**
+//     * Cancels the drowning event.<br>
+//     * Cancellation is mostly equivalent to {@link #setDrowning(boolean)} with a value of false.<br>
+//     * However, this also incurs the usual side effects of cancellation.
+//     */
+//    @Override
+//    public void setCanceled(boolean cancel) {
+//        super.setCanceled(cancel);
+//    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -7,11 +7,14 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 
-public class LivingEntityUseItemEvent extends LivingEvent
-{
+public class LivingEntityUseItemEvent extends LivingEvent {
+    public static final EventBus<LivingEntityUseItemEvent> BUS = EventBus.create(LivingEntityUseItemEvent.class);
+
     private final ItemStack item;
     private int duration;
 
@@ -49,9 +52,9 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * Cancel the event, or set the duration or {@literal <} 0 to prevent it from processing.
      *
      */
-    @Cancelable
-    public static class Start extends LivingEntityUseItemEvent
-    {
+    public static class Start extends LivingEntityUseItemEvent implements Cancellable {
+        public static final CancellableEventBus<Start> BUS = CancellableEventBus.create(Start.class);
+
         public Start(LivingEntity entity, @NotNull ItemStack item, int duration)
         {
             super(entity, item, duration);
@@ -64,9 +67,9 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * Cancel the event, or set the duration to {@literal <=} 0 to cause the player to stop using the item.
      *
      */
-    @Cancelable
-    public static class Tick extends LivingEntityUseItemEvent
-    {
+    public static class Tick extends LivingEntityUseItemEvent implements Cancellable {
+        public static final CancellableEventBus<Tick> BUS = CancellableEventBus.create(Tick.class);
+
         public Tick(LivingEntity entity, @NotNull ItemStack item, int duration)
         {
             super(entity, item, duration);
@@ -85,9 +88,9 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * Canceling this event will prevent the Item from being notified that it has stopped being used,
      * The only vanilla item this would effect are bows, and it would cause them NOT to fire there arrow.
      */
-    @Cancelable
-    public static class Stop extends LivingEntityUseItemEvent
-    {
+    public static class Stop extends LivingEntityUseItemEvent implements Cancellable {
+        public static final CancellableEventBus<Stop> BUS = CancellableEventBus.create(Stop.class);
+
         public Stop(LivingEntity entity, @NotNull ItemStack item, int duration)
         {
             super(entity, item, duration);
@@ -106,8 +109,9 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * The result item stack is the stack that is placed in the player's inventory in replacement of the stack that is currently being used.
      *
      */
-    public static class Finish extends LivingEntityUseItemEvent
-    {
+    public static class Finish extends LivingEntityUseItemEvent {
+        public static final EventBus<Finish> BUS = EventBus.create(Finish.class);
+
         private ItemStack result;
         public Finish(LivingEntity entity, @NotNull ItemStack item, int duration, @NotNull ItemStack result)
         {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class LivingEquipmentChangeEvent extends LivingEvent {
+    public static final EventBus<LivingEquipmentChangeEvent> BUS = EventBus.create(LivingEquipmentChangeEvent.class);
+
     private final EquipmentSlot slot;
     private final ItemStack from;
     private final ItemStack to;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -9,10 +9,11 @@ import net.minecraft.world.entity.Entity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.event.entity.EntityEvent;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,8 +23,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class LivingEvent extends EntityEvent
-{
+public class LivingEvent extends EntityEvent {
+    public static final EventBus<LivingEvent> BUS = EventBus.create(LivingEvent.class);
+
     private final LivingEntity livingEntity;
 
     public LivingEvent(LivingEntity entity)
@@ -50,9 +52,9 @@ public class LivingEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    @Cancelable
-    public static class LivingTickEvent extends LivingEvent
-    {
+    public static class LivingTickEvent extends LivingEvent implements Cancellable {
+        public static final CancellableEventBus<LivingTickEvent> BUS = CancellableEventBus.create(LivingTickEvent.class);
+
         public LivingTickEvent(LivingEntity e){ super(e); }
     }
 
@@ -70,13 +72,15 @@ public class LivingEvent extends EntityEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class LivingJumpEvent extends LivingEvent
-    {
+    public static class LivingJumpEvent extends LivingEvent {
+        public static final EventBus<LivingJumpEvent> BUS = EventBus.create(LivingJumpEvent.class);
+
         public LivingJumpEvent(LivingEntity e){ super(e); }
     }
 
-    public static class LivingVisibilityEvent extends LivingEvent
-    {
+    public static class LivingVisibilityEvent extends LivingEvent {
+        public static final EventBus<LivingVisibilityEvent> BUS = EventBus.create(LivingVisibilityEvent.class);
+
         private double visibilityModifier;
         @Nullable
         private final Entity lookingEntity;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
@@ -7,7 +7,8 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -15,9 +16,9 @@ import org.jetbrains.annotations.Nullable;
  * the amount of experience points dropped or completely prevent dropping of experience
  * by canceling the event.
  */
-@Cancelable
-public class LivingExperienceDropEvent extends LivingEvent
-{
+public class LivingExperienceDropEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingExperienceDropEvent> BUS = CancellableEventBus.create(LivingExperienceDropEvent.class);
+
     @Nullable private final Player attackingPlayer;
     private final int originalExperiencePoints;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
@@ -8,8 +8,9 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingFallEvent is fired when an Entity is set to be falling.<br>
@@ -27,9 +28,9 @@ import net.minecraft.world.entity.LivingEntity;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingFallEvent extends LivingEvent
-{
+public class LivingFallEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingFallEvent> BUS = CancelableEventBus.create(LivingFallEvent.class);
+
     private float distance;
     private float damageMultiplier;
     public LivingFallEvent(LivingEntity entity, float distance, float damageMultiplier)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
@@ -29,7 +29,7 @@ import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class LivingFallEvent extends LivingEvent implements Cancellable {
-    public static final CancellableEventBus<LivingFallEvent> BUS = CancelableEventBus.create(LivingFallEvent.class);
+    public static final CancellableEventBus<LivingFallEvent> BUS = CancellableEventBus.create(LivingFallEvent.class);
 
     private float distance;
     private float damageMultiplier;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingGetProjectileEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingGetProjectileEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired when a living entity attempts to get a projectile with the
@@ -20,8 +21,9 @@ import net.minecraft.world.item.ItemStack;
  * <p>
  * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
  */
-public class LivingGetProjectileEvent extends LivingEvent
-{
+public class LivingGetProjectileEvent extends LivingEvent {
+    public static final EventBus<LivingGetProjectileEvent> BUS = EventBus.create(LivingGetProjectileEvent.class);
+
     private final ItemStack projectileWeaponItemStack;
     private ItemStack projectileItemStack;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
@@ -7,8 +7,9 @@ package net.minecraftforge.event.entity.living;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingHealEvent is fired when an Entity is set to be healed. <br>
@@ -25,9 +26,9 @@ import net.minecraft.world.entity.LivingEntity;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingHealEvent extends LivingEvent
-{
+public class LivingHealEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingHealEvent> BUS = CancellableEventBus.create(LivingHealEvent.class);
+
     private float amount;
     public LivingHealEvent(LivingEntity entity, float amount)
     {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
@@ -9,7 +9,8 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingHurtEvent is fired when an Entity is set to be hurt. <br>
@@ -30,9 +31,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  * @see LivingDamageEvent
  **/
-@net.minecraftforge.eventbus.api.Cancelable
-public class LivingHurtEvent extends LivingEvent
-{
+public class LivingHurtEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingHurtEvent> BUS = CancellableEventBus.create(LivingHurtEvent.class);
+
     private final DamageSource source;
     private float amount;
     public LivingHurtEvent(LivingEntity entity, DamageSource source, float amount)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -12,7 +12,8 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * LivingKnockBackEvent is fired when a living entity is about to be knocked back. <br>
@@ -35,9 +36,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  *<br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class LivingKnockBackEvent extends LivingEvent
-{
+public class LivingKnockBackEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingKnockBackEvent> BUS = CancellableEventBus.create(LivingKnockBackEvent.class);
+
     protected float strength;
     protected double ratioX, ratioZ;
     protected final float originalStrength;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingMakeBrainEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingMakeBrainEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.world.entity.ai.Brain;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BrainBuilder;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * LivingMakeBrainEvent is fired whenever a new {@link net.minecraft.world.entity.ai.Brain} instance is created using {@link LivingEntity#makeBrain(Dynamic)}.<br>
@@ -31,8 +31,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class LivingMakeBrainEvent extends LivingEvent
-{
+public class LivingMakeBrainEvent extends LivingEvent {
+    public static final EventBus<LivingMakeBrainEvent> BUS = EventBus.create(LivingMakeBrainEvent.class);
+
     private final BrainBuilder<?> brainBuilder;
 
     public LivingMakeBrainEvent(LivingEntity entity, BrainBuilder<?> brainBuilder)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
@@ -5,12 +5,13 @@
 
 package net.minecraftforge.event.entity.living;
 
-import net.minecraftforge.eventbus.api.Event.HasResult;
 import net.minecraft.world.entity.Mob;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 @HasResult
-public class LivingPackSizeEvent extends LivingEvent
-{
+public class LivingPackSizeEvent extends LivingEvent {
+    public static final EventBus<LivingPackSizeEvent> BUS = EventBus.create(LivingPackSizeEvent.class);
+
     private int maxPackSize;
     
     public LivingPackSizeEvent(Mob entity)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
@@ -6,13 +6,15 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.Mob;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
-@HasResult
-public class LivingPackSizeEvent extends LivingEvent {
+public class LivingPackSizeEvent extends LivingEvent implements HasResult {
     public static final EventBus<LivingPackSizeEvent> BUS = EventBus.create(LivingPackSizeEvent.class);
 
     private int maxPackSize;
+    private Result result = Result.DEFAULT;
     
     public LivingPackSizeEvent(Mob entity)
     {
@@ -35,5 +37,15 @@ public class LivingPackSizeEvent extends LivingEvent {
     public void setMaxPackSize(int maxPackSize)
     {
         this.maxPackSize = maxPackSize;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSwapItemsEvent.java
@@ -8,11 +8,13 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.ApiStatus;
 
-public class LivingSwapItemsEvent extends LivingEvent
-{
+public class LivingSwapItemsEvent extends LivingEvent {
+    public static final EventBus<LivingSwapItemsEvent> BUS = EventBus.create(LivingSwapItemsEvent.class);
 
     @ApiStatus.Internal
     public LivingSwapItemsEvent(LivingEntity entity)
@@ -26,9 +28,9 @@ public class LivingSwapItemsEvent extends LivingEvent
      *
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
      */
-    @Cancelable
-    public static class Hands extends LivingSwapItemsEvent
-    {
+    public static class Hands extends LivingSwapItemsEvent implements Cancellable {
+        public static final CancellableEventBus<Hands> BUS = CancellableEventBus.create(Hands.class);
+
         private ItemStack toMainHand;
         private ItemStack toOffHand;
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingUseTotemEvent.java
@@ -10,7 +10,8 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -22,9 +23,9 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
-@Cancelable
-public class LivingUseTotemEvent extends LivingEvent
-{
+public class LivingUseTotemEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<LivingUseTotemEvent> BUS = CancellableEventBus.create(LivingUseTotemEvent.class);
+
     private final DamageSource source;
     private final ItemStack totem;
     private final InteractionHand hand;

--- a/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
@@ -8,9 +8,11 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.entity.LivingEntity;
 
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.Nullable;
 
 public class LootingLevelEvent extends LivingEvent {
+    public static final EventBus<LootingLevelEvent> BUS = EventBus.create(LootingLevelEvent.class);
 
     @Nullable
     private final DamageSource damageSource;

--- a/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
@@ -11,6 +11,8 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
@@ -84,9 +86,10 @@ public class MobEffectEvent extends LivingEvent {
      * {@link Result#DENY DENY} will not apply this mob effect.
      * {@link Result#DEFAULT DEFAULT} will run vanilla logic to determine if this mob effect is applicable in {@link LivingEntity#canBeAffected}.
      */
-    @HasResult
-    public static class Applicable extends MobEffectEvent {
+    public static class Applicable extends MobEffectEvent implements HasResult {
         public static final EventBus<Applicable> BUS = EventBus.create(Applicable.class);
+
+        private Result result = Result.DEFAULT;
 
         public Applicable(LivingEntity living, @NotNull MobEffectInstance effectInstance) {
             super(living, effectInstance);
@@ -96,6 +99,16 @@ public class MobEffectEvent extends LivingEvent {
         @NotNull
         public MobEffectInstance getEffectInstance() {
             return super.getEffectInstance();
+        }
+
+        @Override
+        public Result getResult() {
+            return result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobEffectEvent.java
@@ -11,7 +11,9 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,6 +23,8 @@ import org.jetbrains.annotations.Nullable;
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 public class MobEffectEvent extends LivingEvent {
+    public static final EventBus<MobEffectEvent> BUS = EventBus.create(MobEffectEvent.class);
+
     @Nullable
     protected final MobEffectInstance effectInstance;
 
@@ -39,8 +43,9 @@ public class MobEffectEvent extends LivingEvent {
      * This Event is {@link Cancelable}. If canceled, the effect will not be removed.
      * This Event does not have a result.
      */
-    @Cancelable
-    public static class Remove extends MobEffectEvent {
+    public static class Remove extends MobEffectEvent implements Cancellable {
+        public static final CancellableEventBus<Remove> BUS = CancellableEventBus.create(Remove.class);
+
         private final MobEffect effect;
 
         public Remove(LivingEntity living, MobEffect effect) {
@@ -81,6 +86,8 @@ public class MobEffectEvent extends LivingEvent {
      */
     @HasResult
     public static class Applicable extends MobEffectEvent {
+        public static final EventBus<Applicable> BUS = EventBus.create(Applicable.class);
+
         public Applicable(LivingEntity living, @NotNull MobEffectInstance effectInstance) {
             super(living, effectInstance);
         }
@@ -99,6 +106,8 @@ public class MobEffectEvent extends LivingEvent {
      * This event does not have a result.
      */
     public static class Added extends MobEffectEvent {
+        public static final EventBus<Added> BUS = EventBus.create(Added.class);
+
         private final MobEffectInstance oldEffectInstance;
         private final Entity source;
 
@@ -140,6 +149,8 @@ public class MobEffectEvent extends LivingEvent {
      * This event does not have a result.
      */
     public static class Expired extends MobEffectEvent {
+        public static final EventBus<Expired> BUS = EventBus.create(Expired.class);
+
         public Expired(LivingEntity living, MobEffectInstance effect) {
             super(living, effect);
         }

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -6,6 +6,8 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.*;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
@@ -107,8 +109,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @apiNote If your modifications are for a single entity, and do not vary at runtime, use {@link SpawnPlacementRegisterEvent}.
      * @see SpawnPlacementRegisterEvent
      */
-    @HasResult
-    public static class SpawnPlacementCheck extends MutableEvent {
+    public static class SpawnPlacementCheck extends MutableEvent implements HasResult {
         public static final EventBus<SpawnPlacementCheck> BUS = EventBus.create(SpawnPlacementCheck.class);
 
         private final EntityType<?> entityType;
@@ -117,6 +118,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
         private final BlockPos pos;
         private final RandomSource random;
         private final boolean defaultResult;
+        private Result result = Result.DEFAULT;
 
         /**
          * Internal.
@@ -177,6 +179,16 @@ public abstract class MobSpawnEvent extends EntityEvent {
         public boolean getDefaultResult() {
             return this.defaultResult;
         }
+
+        @Override
+        public Result getResult() {
+            return this.result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
+        }
     }
 
     /**
@@ -206,13 +218,13 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @see {@link SpawnPlacementRegisterEvent} To modify spawn placements statically at startup.
      * @see {@link SpawnPlacementCheck} To modify the result of spawn placements at runtime.
      */
-    @HasResult
-    public static class PositionCheck extends MobSpawnEvent {
+    public static class PositionCheck extends MobSpawnEvent implements HasResult {
         public static final EventBus<PositionCheck> BUS = EventBus.create(PositionCheck.class);
 
         @Nullable
         private final BaseSpawner spawner;
         private final EntitySpawnReason spawnReason;
+        private Result result = Result.DEFAULT;
 
         public PositionCheck(Mob mob, ServerLevelAccessor level, EntitySpawnReason spawnReason, @Nullable BaseSpawner spawner) {
             super(mob, level, mob.getX(), mob.getY(), mob.getZ());
@@ -237,6 +249,16 @@ public abstract class MobSpawnEvent extends EntityEvent {
          */
         public EntitySpawnReason getSpawnReason() {
             return this.spawnReason;
+        }
+
+        @Override
+        public Result getResult() {
+            return this.result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
         }
     }
 
@@ -391,12 +413,23 @@ public abstract class MobSpawnEvent extends EntityEvent {
      */
     // TODO: 1.20 Move to standalone class, as it is unrelated to the complex mob spawning flow.
     // Such a refactor will allow the BaseSpawner and MobSpawnType params to be hoisted to MobSpawnEvent.
-    @HasResult
-    public static class AllowDespawn extends MobSpawnEvent {
+    public static class AllowDespawn extends MobSpawnEvent implements HasResult {
         public static final EventBus<AllowDespawn> BUS = EventBus.create(AllowDespawn.class);
+
+        private Result result = Result.DEFAULT;
 
         public AllowDespawn(Mob mob, ServerLevelAccessor level) {
             super(mob, level, mob.getX(), mob.getY(), mob.getZ());
+        }
+
+        @Override
+        public Result getResult() {
+            return this.result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.*;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.common.util.HasResult;
 import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
@@ -274,7 +275,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @see ForgeEventFactory#onFinalizeSpawn
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      */
-    public static class FinalizeSpawn extends MobSpawnEvent implements Cancellable {
+    public static class FinalizeSpawn extends MobSpawnEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<FinalizeSpawn> BUS = CancellableEventBus.create(FinalizeSpawn.class);
 
         private final EntitySpawnReason spawnReason;

--- a/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MobSpawnEvent.java
@@ -6,6 +6,10 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.world.entity.*;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,8 +25,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.SpawnPlacementRegisterEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -37,6 +39,8 @@ import net.minecraftforge.fml.LogicalSide;
  * {@link AllowDespawn} is not related to the mob spawn event flow, as it fires when a despawn is attempted.
  */
 public abstract class MobSpawnEvent extends EntityEvent {
+    public static final EventBus<MobSpawnEvent> BUS = EventBus.create(MobSpawnEvent.class);
+
     private final ServerLevelAccessor level;
     private final double x;
     private final double y;
@@ -104,7 +108,9 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @see SpawnPlacementRegisterEvent
      */
     @HasResult
-    public static class SpawnPlacementCheck extends Event {
+    public static class SpawnPlacementCheck extends MutableEvent {
+        public static final EventBus<SpawnPlacementCheck> BUS = EventBus.create(SpawnPlacementCheck.class);
+
         private final EntityType<?> entityType;
         private final ServerLevelAccessor level;
         private final EntitySpawnReason spawnReason;
@@ -202,6 +208,8 @@ public abstract class MobSpawnEvent extends EntityEvent {
      */
     @HasResult
     public static class PositionCheck extends MobSpawnEvent {
+        public static final EventBus<PositionCheck> BUS = EventBus.create(PositionCheck.class);
+
         @Nullable
         private final BaseSpawner spawner;
         private final EntitySpawnReason spawnReason;
@@ -244,8 +252,9 @@ public abstract class MobSpawnEvent extends EntityEvent {
      * @see ForgeEventFactory#onFinalizeSpawn
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
      */
-    @Cancelable
-    public static class FinalizeSpawn extends MobSpawnEvent {
+    public static class FinalizeSpawn extends MobSpawnEvent implements Cancellable {
+        public static final CancellableEventBus<FinalizeSpawn> BUS = CancellableEventBus.create(FinalizeSpawn.class);
+
         private final EntitySpawnReason spawnReason;
         @Nullable
         private final BaseSpawner spawner;
@@ -384,6 +393,8 @@ public abstract class MobSpawnEvent extends EntityEvent {
     // Such a refactor will allow the BaseSpawner and MobSpawnType params to be hoisted to MobSpawnEvent.
     @HasResult
     public static class AllowDespawn extends MobSpawnEvent {
+        public static final EventBus<AllowDespawn> BUS = EventBus.create(AllowDespawn.class);
+
         public AllowDespawn(Mob mob, ServerLevelAccessor level) {
             super(mob, level, mob.getX(), mob.getY(), mob.getZ());
         }

--- a/src/main/java/net/minecraftforge/event/entity/living/MonsterDisguiseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/MonsterDisguiseEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.extensions.IForgeItem;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event is fired on the forge bus before an Monster detects that a player is looking at them.
@@ -19,8 +20,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * <p>
  * This event does not have a {@link Result}.
  */
-@Cancelable
-public class MonsterDisguiseEvent extends LivingEvent {
+public class MonsterDisguiseEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<MonsterDisguiseEvent> BUS = CancellableEventBus.create(MonsterDisguiseEvent.class);
+
     private final Player player;
 
     public MonsterDisguiseEvent(Monster monster, Player player) {

--- a/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
@@ -8,6 +8,7 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
@@ -18,7 +19,7 @@ import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
  * Note: The shield item stack "should" be available from {@link LivingEntity#getUseItem()}
  * at least for players.
  */
-public class ShieldBlockEvent extends LivingEvent implements Cancellable {
+public class ShieldBlockEvent extends LivingEvent implements Cancellable, CancellableAware {
     public static final CancellableEventBus<ShieldBlockEvent> BUS = CancellableEventBus.create(ShieldBlockEvent.class);
 
     private final DamageSource source;

--- a/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ShieldBlockEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.event.entity.living;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * The ShieldBlockEvent is fired when an entity successfully blocks with a shield.<br>
@@ -17,9 +18,9 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * Note: The shield item stack "should" be available from {@link LivingEntity#getUseItem()}
  * at least for players.
  */
-@Cancelable
-public class ShieldBlockEvent extends LivingEvent
-{
+public class ShieldBlockEvent extends LivingEvent implements Cancellable {
+    public static final CancellableEventBus<ShieldBlockEvent> BUS = CancellableEventBus.create(ShieldBlockEvent.class);
+
     private final DamageSource source;
     private final float originalBlocked;
     private float dmgBlocked;

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -11,7 +11,7 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.EntityEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * ZombieEvent is fired whenever a zombie is spawned for aid.
@@ -21,6 +21,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class ZombieEvent extends EntityEvent {
+    public static final EventBus<ZombieEvent> BUS = EventBus.create(ZombieEvent.class);
+
     private final Zombie zombie;
 
     public ZombieEvent(Zombie zombie)
@@ -60,6 +62,8 @@ public class ZombieEvent extends EntityEvent {
      **/
     @HasResult
     public static class SummonAidEvent extends ZombieEvent {
+        public static final EventBus<SummonAidEvent> BUS = EventBus.create(SummonAidEvent.class);
+
         private Zombie customSummonedAid;
 
         private final Level level;

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.eventbus.api.bus.EventBus;
@@ -60,11 +62,11 @@ public class ZombieEvent extends EntityEvent {
      *
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    @HasResult
-    public static class SummonAidEvent extends ZombieEvent {
+    public static class SummonAidEvent extends ZombieEvent implements HasResult {
         public static final EventBus<SummonAidEvent> BUS = EventBus.create(SummonAidEvent.class);
 
         private Zombie customSummonedAid;
+        private Result result = Result.DEFAULT;
 
         private final Level level;
         private final int x;
@@ -95,5 +97,15 @@ public class ZombieEvent extends EntityEvent {
         public int getZ() { return z; }
         public LivingEntity getAttacker() { return attacker; }
         public double getSummonChance() { return summonChance; }
+
+        @Override
+        public Result getResult() {
+            return result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
@@ -10,6 +10,7 @@ import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Base class used for advancement-related events. Should not be used directly.
@@ -17,6 +18,8 @@ import net.minecraftforge.common.MinecraftForge;
  * @see AdvancementProgressEvent
  */
 public class AdvancementEvent extends PlayerEvent {
+    public static final EventBus<AdvancementEvent> BUS = EventBus.create(AdvancementEvent.class);
+
     private final AdvancementHolder advancement;
 
     public AdvancementEvent(Player player, AdvancementHolder advancement) {
@@ -42,6 +45,8 @@ public class AdvancementEvent extends PlayerEvent {
      * @see AdvancementProgress#isDone()
      */
     public static class AdvancementEarnEvent extends AdvancementEvent {
+        public static final EventBus<AdvancementEarnEvent> BUS = EventBus.create(AdvancementEarnEvent.class);
+
         public AdvancementEarnEvent(Player player, AdvancementHolder earned) {
             super(player, earned);
         }
@@ -60,6 +65,8 @@ public class AdvancementEvent extends PlayerEvent {
      * @see net.minecraft.server.PlayerAdvancements#revoke(Advancement, String)
      */
     public static class AdvancementProgressEvent extends AdvancementEvent {
+        public static final EventBus<AdvancementProgressEvent> BUS = EventBus.create(AdvancementProgressEvent.class);
+
         private final AdvancementProgress advancementProgress;
         private final String criterionName;
         private final AdvancementEvent.AdvancementProgressEvent.ProgressType progressType;

--- a/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
@@ -7,6 +7,7 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -16,8 +17,9 @@ import org.jetbrains.annotations.NotNull;
  *
  * ItemStacks are the inputs/output from the anvil. They cannot be edited.
  */
-public class AnvilRepairEvent extends PlayerEvent
-{
+public class AnvilRepairEvent extends PlayerEvent {
+    public static final EventBus<AnvilRepairEvent> BUS = EventBus.create(AnvilRepairEvent.class);
+
     @NotNull
     private final ItemStack left; // The left side of the input
     @NotNull

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
@@ -8,10 +8,11 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.BowItem;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -30,9 +31,9 @@ import org.jetbrains.annotations.NotNull;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class ArrowLooseEvent extends PlayerEvent
-{
+public class ArrowLooseEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<ArrowLooseEvent> BUS = CancellableEventBus.create(ArrowLooseEvent.class);
+
     private final ItemStack bow;
     private final Level level;
     private final boolean hasAmmo;

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
@@ -12,6 +12,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,6 +23,8 @@ import org.jetbrains.annotations.NotNull;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class ArrowNockEvent extends PlayerEvent {
+    public static final EventBus<ArrowNockEvent> BUS = EventBus.create(ArrowNockEvent.class);
+
     private final ItemStack bow;
     private final InteractionHand hand;
     private final Level level;

--- a/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
@@ -6,9 +6,10 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * AttackEntityEvent is fired when a player attacks an Entity.<br>
@@ -24,9 +25,9 @@ import net.minecraft.world.entity.player.Player;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class AttackEntityEvent extends PlayerEvent
-{
+public class AttackEntityEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<AttackEntityEvent> BUS = CancellableEventBus.create(AttackEntityEvent.class);
+
     private final Entity target;
     public AttackEntityEvent(Player player, Entity target)
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
@@ -24,15 +26,15 @@ import org.jetbrains.annotations.Nullable;
  *
  * setResult(ALLOW) is the same as the old setHandled()
  */
-@HasResult
 // TODO: Redesign BonemealEvent the whole thing, it doens't make sense.
-public class BonemealEvent extends PlayerEvent implements Cancellable {
+public class BonemealEvent extends PlayerEvent implements Cancellable, HasResult {
     public static final CancellableEventBus<BonemealEvent> BUS = CancellableEventBus.create(BonemealEvent.class);
 
     private final Level level;
     private final BlockPos pos;
     private final BlockState block;
     private final ItemStack stack;
+    private Result result = Result.DEFAULT;
 
     public BonemealEvent(@Nullable Player player, Level level, BlockPos pos, BlockState block, ItemStack stack) {
         super(player);
@@ -57,5 +59,15 @@ public class BonemealEvent extends PlayerEvent implements Cancellable {
     @NotNull
     public ItemStack getStack() {
         return stack;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
@@ -5,13 +5,13 @@
 
 package net.minecraftforge.event.entity.player;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event.HasResult;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,10 +24,11 @@ import org.jetbrains.annotations.Nullable;
  *
  * setResult(ALLOW) is the same as the old setHandled()
  */
-@Cancelable
 @HasResult
 // TODO: Redesign BonemealEvent the whole thing, it doens't make sense.
-public class BonemealEvent extends PlayerEvent {
+public class BonemealEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<BonemealEvent> BUS = CancellableEventBus.create(BonemealEvent.class);
+
     private final Level level;
     private final BlockPos pos;
     private final BlockState block;

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -6,10 +6,9 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event.HasResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired whenever a player attacks an Entity in
@@ -25,8 +24,9 @@ import net.minecraft.world.entity.player.Player;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @HasResult
-public class CriticalHitEvent extends PlayerEvent
-{
+public class CriticalHitEvent extends PlayerEvent {
+    public static final EventBus<CriticalHitEvent> BUS = EventBus.create(CriticalHitEvent.class);
+
     private float damageModifier;
     private final float oldDamageModifier;
     private final Entity target;

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.event.entity.player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
@@ -23,11 +25,11 @@ import net.minecraftforge.eventbus.api.bus.EventBus;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@HasResult
-public class CriticalHitEvent extends PlayerEvent {
+public class CriticalHitEvent extends PlayerEvent implements HasResult {
     public static final EventBus<CriticalHitEvent> BUS = EventBus.create(CriticalHitEvent.class);
 
     private float damageModifier;
+    private Result result = Result.DEFAULT;
     private final float oldDamageModifier;
     private final Entity target;
     private final boolean vanillaCritical;
@@ -82,5 +84,15 @@ public class CriticalHitEvent extends PlayerEvent {
     public boolean isVanillaCritical()
     {
         return vanillaCritical;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
@@ -7,6 +7,8 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
@@ -20,11 +22,11 @@ import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
  *
  *  setResult(ALLOW) is the same as the old setHandled()
  */
-@HasResult
-public class EntityItemPickupEvent extends PlayerEvent implements Cancellable {
+public class EntityItemPickupEvent extends PlayerEvent implements Cancellable, HasResult {
     public static final CancellableEventBus<EntityItemPickupEvent> BUS = CancellableEventBus.create(EntityItemPickupEvent.class);
 
     private final ItemEntity item;
+    private Result result = Result.DEFAULT;
 
     public EntityItemPickupEvent(Player player, ItemEntity item)
     {
@@ -35,5 +37,15 @@ public class EntityItemPickupEvent extends PlayerEvent implements Cancellable {
     public ItemEntity getItem()
     {
         return item;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
@@ -5,10 +5,10 @@
 
 package net.minecraftforge.event.entity.player;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event is called when a player collides with a EntityItem on the ground.
@@ -20,10 +20,10 @@ import net.minecraft.world.entity.player.Player;
  *
  *  setResult(ALLOW) is the same as the old setHandled()
  */
-@Cancelable
-@Event.HasResult
-public class EntityItemPickupEvent extends PlayerEvent
-{
+@HasResult
+public class EntityItemPickupEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<EntityItemPickupEvent> BUS = CancellableEventBus.create(EntityItemPickupEvent.class);
+
     private final ItemEntity item;
 
     public EntityItemPickupEvent(Player player, ItemEntity item)

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -5,12 +5,12 @@
 
 package net.minecraftforge.event.entity.player;
 
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,10 +23,9 @@ import org.jetbrains.annotations.Nullable;
  * ItemStack to your inventory and reducing the stack size to process.
  * setResult(ALLOW) is the same as the old setHandled();
  */
-@Cancelable
-@Event.HasResult
-public class FillBucketEvent extends PlayerEvent
-{
+@HasResult
+public class FillBucketEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<FillBucketEvent> BUS = CancellableEventBus.create(FillBucketEvent.class);
 
     private final ItemStack current;
     private final Level level;

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
@@ -23,8 +25,7 @@ import org.jetbrains.annotations.Nullable;
  * ItemStack to your inventory and reducing the stack size to process.
  * setResult(ALLOW) is the same as the old setHandled();
  */
-@HasResult
-public class FillBucketEvent extends PlayerEvent implements Cancellable {
+public class FillBucketEvent extends PlayerEvent implements Cancellable, HasResult {
     public static final CancellableEventBus<FillBucketEvent> BUS = CancellableEventBus.create(FillBucketEvent.class);
 
     private final ItemStack current;
@@ -33,6 +34,7 @@ public class FillBucketEvent extends PlayerEvent implements Cancellable {
     private final HitResult target;
 
     private ItemStack result;
+    private Result eventResult = Result.DEFAULT;
 
     public FillBucketEvent(Player player, @NotNull ItemStack current, Level level, @Nullable HitResult target)
     {
@@ -50,4 +52,14 @@ public class FillBucketEvent extends PlayerEvent implements Cancellable {
     @NotNull
     public ItemStack getFilledBucket() { return this.result; }
     public void setFilledBucket(@NotNull ItemStack bucket) { this.result = bucket; }
+
+    @Override
+    public Result getResult() {
+        return this.eventResult;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.eventResult = result;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
@@ -22,7 +23,7 @@ import java.util.List;
  * Canceling the event will cause the player to receive no items at all.
  * The hook will still take the damage specified
  */
-public class ItemFishedEvent extends PlayerEvent implements Cancellable {
+public class ItemFishedEvent extends PlayerEvent implements Cancellable, CancellableAware {
     public static final CancellableEventBus<ItemFishedEvent> BUS = CancellableEventBus.create(ItemFishedEvent.class);
 
     private final NonNullList<ItemStack> stacks = NonNullList.create();

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -9,7 +9,8 @@ import com.google.common.base.Preconditions;
 import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 import javax.annotation.Nonnegative;
 import java.util.List;
@@ -21,8 +22,9 @@ import java.util.List;
  * Canceling the event will cause the player to receive no items at all.
  * The hook will still take the damage specified
  */
-@Cancelable
-public class ItemFishedEvent extends PlayerEvent {
+public class ItemFishedEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<ItemFishedEvent> BUS = CancellableEventBus.create(ItemFishedEvent.class);
+
     private final NonNullList<ItemStack> stacks = NonNullList.create();
     private final FishingHook hook;
     private int rodDamage;

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -12,11 +12,13 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.network.chat.Component;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ItemTooltipEvent extends PlayerEvent
-{
+public class ItemTooltipEvent extends PlayerEvent {
+    public static final EventBus<ItemTooltipEvent> BUS = EventBus.create(ItemTooltipEvent.class);
+
     private final TooltipFlag flags;
     @NotNull
     private final ItemStack itemStack;

--- a/src/main/java/net/minecraftforge/event/entity/player/PermissionsChangedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PermissionsChangedEvent.java
@@ -6,16 +6,17 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * This event will fire when the player is opped or deopped.
  * <p>
  * This event is cancelable which will stop the op or deop from happening.
  */
-@Cancelable
-public class PermissionsChangedEvent extends PlayerEvent
-{
+public class PermissionsChangedEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<PermissionsChangedEvent> BUS = CancellableEventBus.create(PermissionsChangedEvent.class);
+
     private final int newLevel;
     private final int oldLevel;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
@@ -7,9 +7,11 @@ package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
-public class PlayerContainerEvent extends PlayerEvent
-{
+public class PlayerContainerEvent extends PlayerEvent {
+    public static final EventBus<PlayerContainerEvent> BUS = EventBus.create(PlayerContainerEvent.class);
+
     private final AbstractContainerMenu container;
     public PlayerContainerEvent(Player player, AbstractContainerMenu container)
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -20,7 +20,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,6 +49,8 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 public class PlayerDestroyItemEvent extends PlayerEvent {
+    public static final EventBus<PlayerDestroyItemEvent> BUS = EventBus.create(PlayerDestroyItemEvent.class);
+
     @NotNull
     private final ItemStack original;
     @Nullable

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -17,13 +17,15 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,8 +36,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class PlayerEvent extends LivingEvent
-{
+public class PlayerEvent extends LivingEvent {
+    public static final EventBus<PlayerEvent> BUS = EventBus.create(PlayerEvent.class);
+
     private final Player player;
 
     public PlayerEvent(Player player)
@@ -66,8 +69,9 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class HarvestCheck extends PlayerEvent
-    {
+    public static class HarvestCheck extends PlayerEvent {
+        public static final EventBus<HarvestCheck> BUS = EventBus.create(HarvestCheck.class);
+
         private final BlockState state;
         private boolean success;
 
@@ -102,9 +106,9 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    @Cancelable
-    public static class BreakSpeed extends PlayerEvent
-    {
+    public static class BreakSpeed extends PlayerEvent implements Cancellable {
+        public static final CancellableEventBus<BreakSpeed> BUS = CancellableEventBus.create(BreakSpeed.class);
+
         private static final BlockPos LEGACY_UNKNOWN = new BlockPos(0, -1, 0);
         private final BlockState state;
         private final float originalSpeed;
@@ -143,8 +147,9 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class NameFormat extends PlayerEvent
-    {
+    public static class NameFormat extends PlayerEvent {
+        public static final EventBus<NameFormat> BUS = EventBus.create(NameFormat.class);
+
         private final Component username;
         private Component displayname;
 
@@ -186,8 +191,9 @@ public class PlayerEvent extends LivingEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
      **/
-    public static class TabListNameFormat extends PlayerEvent
-    {
+    public static class TabListNameFormat extends PlayerEvent {
+        public static final EventBus<TabListNameFormat> BUS = EventBus.create(TabListNameFormat.class);
+
         @Nullable
         private Component displayName;
 
@@ -212,8 +218,9 @@ public class PlayerEvent extends LivingEvent
      * Fired when the EntityPlayer is cloned, typically caused by the impl sending a RESPAWN_PLAYER event.
      * Either caused by death, or by traveling from the End to the overworld.
      */
-    public static class Clone extends PlayerEvent
-    {
+    public static class Clone extends PlayerEvent {
+        public static final EventBus<Clone> BUS = EventBus.create(Clone.class);
+
         private final Player original;
         private final boolean wasDeath;
 
@@ -247,6 +254,7 @@ public class PlayerEvent extends LivingEvent
      *
      */
     public static class StartTracking extends PlayerEvent {
+        public static final EventBus<StartTracking> BUS = EventBus.create(StartTracking.class);
 
         private final Entity target;
 
@@ -270,6 +278,7 @@ public class PlayerEvent extends LivingEvent
      *
      */
     public static class StopTracking extends PlayerEvent {
+        public static final EventBus<StopTracking> BUS = EventBus.create(StopTracking.class);
 
         private final Entity target;
 
@@ -295,6 +304,8 @@ public class PlayerEvent extends LivingEvent
      * containing additional mod related player data.
      */
     public static class LoadFromFile extends PlayerEvent {
+        public static final EventBus<LoadFromFile> BUS = EventBus.create(LoadFromFile.class);
+
         private final File playerDirectory;
         private final String playerUUID;
 
@@ -347,6 +358,8 @@ public class PlayerEvent extends LivingEvent
      * corrupt the world state.
      */
     public static class SaveToFile extends PlayerEvent {
+        public static final EventBus<SaveToFile> BUS = EventBus.create(SaveToFile.class);
+
         private final File playerDirectory;
         private final String playerUUID;
 
@@ -387,6 +400,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class ItemPickupEvent extends PlayerEvent {
+        public static final EventBus<ItemPickupEvent> BUS = EventBus.create(ItemPickupEvent.class);
+
         /**
          * Original EntityItem with current remaining stack size
          */
@@ -412,6 +427,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class ItemCraftedEvent extends PlayerEvent {
+        public static final EventBus<ItemCraftedEvent> BUS = EventBus.create(ItemCraftedEvent.class);
+
         @NotNull
         private final ItemStack crafting;
         private final Container craftMatrix;
@@ -435,6 +452,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class ItemSmeltedEvent extends PlayerEvent {
+        public static final EventBus<ItemSmeltedEvent> BUS = EventBus.create(ItemSmeltedEvent.class);
+
         @NotNull
         private final ItemStack smelting;
         public ItemSmeltedEvent(Player player, @NotNull ItemStack crafting)
@@ -451,6 +470,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class PlayerLoggedInEvent extends PlayerEvent {
+        public static final EventBus<PlayerLoggedInEvent> BUS = EventBus.create(PlayerLoggedInEvent.class);
+
         public PlayerLoggedInEvent(Player player)
         {
             super(player);
@@ -458,6 +479,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class PlayerLoggedOutEvent extends PlayerEvent {
+        public static final EventBus<PlayerLoggedOutEvent> BUS = EventBus.create(PlayerLoggedOutEvent.class);
+
         public PlayerLoggedOutEvent(Player player)
         {
             super(player);
@@ -465,6 +488,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class PlayerRespawnEvent extends PlayerEvent {
+        public static final EventBus<PlayerRespawnEvent> BUS = EventBus.create(PlayerRespawnEvent.class);
+
         private final boolean endConquered;
 
         public PlayerRespawnEvent(Player player, boolean endConquered)
@@ -486,6 +511,8 @@ public class PlayerEvent extends LivingEvent
     }
 
     public static class PlayerChangedDimensionEvent extends PlayerEvent {
+        public static final EventBus<PlayerChangedDimensionEvent> BUS = EventBus.create(PlayerChangedDimensionEvent.class);
+
         private final ResourceKey<Level> fromDim;
         private final ResourceKey<Level> toDim;
         public PlayerChangedDimensionEvent(Player player, ResourceKey<Level> fromDim, ResourceKey<Level> toDim)
@@ -510,9 +537,9 @@ public class PlayerEvent extends LivingEvent
      * Fired when the game type of a server player is changed to a different value than what it was previously. Eg Creative to Survival, not Survival to Survival.
      * If the event is cancelled the game mode of the player is not changed and the value of <code>newGameMode</code> is ignored.
      */
-    @Cancelable
-    public static class PlayerChangeGameModeEvent extends PlayerEvent
-    {
+    public static class PlayerChangeGameModeEvent extends PlayerEvent implements Cancellable {
+        public static final CancellableEventBus<PlayerChangeGameModeEvent> BUS = CancellableEventBus.create(PlayerChangeGameModeEvent.class);
+
         private final GameType currentGameMode;
         private GameType newGameMode;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
@@ -6,14 +6,16 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Occurs when a player falls, but is able to fly.  Doesn't need to be cancelable, this is mainly for notification purposes.
  * @author Mithion
  *
  */
-public class PlayerFlyableFallEvent extends PlayerEvent
-{
+public class PlayerFlyableFallEvent extends PlayerEvent {
+    public static final EventBus<PlayerFlyableFallEvent> BUS = EventBus.create(PlayerFlyableFallEvent.class);
+
     private float distance;
     private float multiplier;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -25,6 +25,9 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 
+import net.minecraftforge.common.util.CancellableAware;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
@@ -64,7 +67,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Let result be the return value of {@link Entity#interactAt(Player, Vec3, InteractionHand)}, or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link EntityInteract}.
      */
-    public static class EntityInteractSpecific extends PlayerInteractEvent implements Cancellable {
+    public static class EntityInteractSpecific extends PlayerInteractEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<EntityInteractSpecific> BUS = CancellableEventBus.create(EntityInteractSpecific.class);
 
         private final Vec3 localPos;
@@ -104,7 +107,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link RightClickItem}.
      */
-    public static class EntityInteract extends PlayerInteractEvent implements Cancellable {
+    public static class EntityInteract extends PlayerInteractEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<EntityInteract> BUS = CancellableEventBus.create(EntityInteract.class);
 
         private final Entity target;
@@ -132,7 +135,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * There are various results to this event, see the getters below.  <br>
      * Note that handling things differently on the client vs server may cause desynchronizations!
      */
-    public static class RightClickBlock extends PlayerInteractEvent implements Cancellable {
+    public static class RightClickBlock extends PlayerInteractEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<RightClickBlock> BUS = CancellableEventBus.create(RightClickBlock.class);
 
         private Result useBlock = Result.DEFAULT;
@@ -184,14 +187,15 @@ public class PlayerInteractEvent extends PlayerEvent {
             this.useItem = triggerItem;
         }
 
-        @Override
-        public void setCanceled(boolean canceled) {
-            super.setCanceled(canceled);
-            if (canceled) {
-                useBlock = Result.DENY;
-                useItem = Result.DENY;
-            }
-        }
+        // Todo: [Forge][Event] PlayerInteractEvent.RightClickBlock#setCanceled(boolean) override
+//        @Override
+//        public void setCanceled(boolean canceled) {
+//            super.setCanceled(canceled);
+//            if (canceled) {
+//                useBlock = Result.DENY;
+//                useItem = Result.DENY;
+//            }
+//        }
     }
 
     /**
@@ -201,7 +205,7 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Let result be the return value of {@link Item#use(Level, Player, InteractionHand)}, or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then continue to other hands.
      */
-    public static class RightClickItem extends PlayerInteractEvent implements Cancellable {
+    public static class RightClickItem extends PlayerInteractEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<RightClickItem> BUS = CancellableEventBus.create(RightClickItem.class);
 
         public RightClickItem(Player player, InteractionHand hand) {
@@ -237,12 +241,13 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Also note that creative mode directly breaks the block without running any other logic.
      * Therefore, in creative mode, {@link #setUseBlock} and {@link #setUseItem} have no effect.
      */
-    public static class LeftClickBlock extends PlayerInteractEvent {
+    public static class LeftClickBlock extends PlayerInteractEvent implements Cancellable, HasResult, CancellableAware {
         public static final CancellableEventBus<LeftClickBlock> BUS = CancellableEventBus.create(LeftClickBlock.class);
 
         private Result useBlock = Result.DEFAULT;
         private Result useItem = Result.DEFAULT;
         private final Action action;
+        private Result result = Result.DEFAULT;
 
         @ApiStatus.Internal
         public LeftClickBlock(Player player, BlockPos pos, Direction face, Action action) {
@@ -278,6 +283,16 @@ public class PlayerInteractEvent extends PlayerEvent {
 
         public void setUseItem(Result triggerItem) {
             this.useItem = triggerItem;
+        }
+
+        @Override
+        public Result getResult() {
+            return result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
         }
 
         // Todo: [Forge][Event] PlayerInteractEvent.LeftClickBlock#setCanceled(boolean) override

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -24,8 +24,10 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
 
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -38,6 +40,8 @@ import org.jetbrains.annotations.Nullable;
  * See the individual documentation on each subevent for more details.
  **/
 public class PlayerInteractEvent extends PlayerEvent {
+    public static final EventBus<PlayerInteractEvent> BUS = EventBus.create(PlayerInteractEvent.class);
+
     private final InteractionHand hand;
     private final BlockPos pos;
     @Nullable
@@ -60,8 +64,9 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Let result be the return value of {@link Entity#interactAt(Player, Vec3, InteractionHand)}, or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link EntityInteract}.
      */
-    @Cancelable
-    public static class EntityInteractSpecific extends PlayerInteractEvent {
+    public static class EntityInteractSpecific extends PlayerInteractEvent implements Cancellable {
+        public static final CancellableEventBus<EntityInteractSpecific> BUS = CancellableEventBus.create(EntityInteractSpecific.class);
+
         private final Vec3 localPos;
         private final Entity target;
 
@@ -99,8 +104,9 @@ public class PlayerInteractEvent extends PlayerEvent {
      * or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link RightClickItem}.
      */
-    @Cancelable
-    public static class EntityInteract extends PlayerInteractEvent {
+    public static class EntityInteract extends PlayerInteractEvent implements Cancellable {
+        public static final CancellableEventBus<EntityInteract> BUS = CancellableEventBus.create(EntityInteract.class);
+
         private final Entity target;
 
         public EntityInteract(Player player, InteractionHand hand, Entity target) {
@@ -126,8 +132,9 @@ public class PlayerInteractEvent extends PlayerEvent {
      * There are various results to this event, see the getters below.  <br>
      * Note that handling things differently on the client vs server may cause desynchronizations!
      */
-    @Cancelable
-    public static class RightClickBlock extends PlayerInteractEvent {
+    public static class RightClickBlock extends PlayerInteractEvent implements Cancellable {
+        public static final CancellableEventBus<RightClickBlock> BUS = CancellableEventBus.create(RightClickBlock.class);
+
         private Result useBlock = Result.DEFAULT;
         private Result useItem = Result.DEFAULT;
         private BlockHitResult hitVec;
@@ -194,8 +201,9 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Let result be the return value of {@link Item#use(Level, Player, InteractionHand)}, or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then continue to other hands.
      */
-    @Cancelable
-    public static class RightClickItem extends PlayerInteractEvent {
+    public static class RightClickItem extends PlayerInteractEvent implements Cancellable {
+        public static final CancellableEventBus<RightClickItem> BUS = CancellableEventBus.create(RightClickItem.class);
+
         public RightClickItem(Player player, InteractionHand hand) {
             super(player, hand, player.blockPosition(), null);
         }
@@ -207,6 +215,8 @@ public class PlayerInteractEvent extends PlayerEvent {
      * This event cannot be canceled.
      */
     public static class RightClickEmpty extends PlayerInteractEvent {
+        public static final EventBus<RightClickEmpty> BUS = EventBus.create(RightClickEmpty.class);
+
         public RightClickEmpty(Player player, InteractionHand hand) {
             super(player, hand, player.blockPosition(), null);
         }
@@ -227,8 +237,9 @@ public class PlayerInteractEvent extends PlayerEvent {
      * Also note that creative mode directly breaks the block without running any other logic.
      * Therefore, in creative mode, {@link #setUseBlock} and {@link #setUseItem} have no effect.
      */
-    @Cancelable
     public static class LeftClickBlock extends PlayerInteractEvent {
+        public static final CancellableEventBus<LeftClickBlock> BUS = CancellableEventBus.create(LeftClickBlock.class);
+
         private Result useBlock = Result.DEFAULT;
         private Result useItem = Result.DEFAULT;
         private final Action action;
@@ -269,14 +280,15 @@ public class PlayerInteractEvent extends PlayerEvent {
             this.useItem = triggerItem;
         }
 
-        @Override
-        public void setCanceled(boolean canceled) {
-            super.setCanceled(canceled);
-            if (canceled) {
-                useBlock = Result.DENY;
-                useItem = Result.DENY;
-            }
-        }
+        // Todo: [Forge][Event] PlayerInteractEvent.LeftClickBlock#setCanceled(boolean) override
+//        @Override
+//        public void setCanceled(boolean canceled) {
+//            super.setCanceled(canceled);
+//            if (canceled) {
+//                useBlock = Result.DENY;
+//                useItem = Result.DENY;
+//            }
+//        }
 
         public static enum Action {
             /**
@@ -314,6 +326,8 @@ public class PlayerInteractEvent extends PlayerEvent {
      * This event cannot be canceled.
      */
     public static class LeftClickEmpty extends PlayerInteractEvent {
+        public static final EventBus<LeftClickEmpty> BUS = EventBus.create(LeftClickEmpty.class);
+
         public LeftClickEmpty(Player player) {
             super(player, InteractionHand.MAIN_HAND, player.blockPosition(), null);
         }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
@@ -9,16 +9,17 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * This event is fired when a player's spawn point is set or reset.<br>
  * The event can be canceled, which will prevent the spawn point from being changed.
  */
-@Cancelable
-public class PlayerSetSpawnEvent extends PlayerEvent
-{
+public class PlayerSetSpawnEvent extends PlayerEvent implements Cancellable {
+    public static final CancellableEventBus<PlayerSetSpawnEvent> BUS = CancellableEventBus.create(PlayerSetSpawnEvent.class);
+
     private final ResourceKey<Level> spawnLevel;
     private final boolean forced;
     @Nullable

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Player.BedSleepingProblem;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 import java.util.Optional;
 
@@ -24,8 +25,9 @@ import java.util.Optional;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-public class PlayerSleepInBedEvent extends PlayerEvent
-{
+public class PlayerSleepInBedEvent extends PlayerEvent {
+    public static final EventBus<PlayerSleepInBedEvent> BUS = EventBus.create(PlayerSleepInBedEvent.class);
+
     private BedSleepingProblem result = null;
     private final Optional<BlockPos> pos;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.level.levelgen.PhantomSpawner;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,11 +24,11 @@ import org.jetbrains.annotations.NotNull;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  * @see PlayerSpawnPhantomsEvent#setResult for the effects of each result.
  */
-@HasResult
-public class PlayerSpawnPhantomsEvent extends PlayerEvent {
+public class PlayerSpawnPhantomsEvent extends PlayerEvent implements HasResult {
     public static final EventBus<PlayerSpawnPhantomsEvent> BUS = EventBus.create(PlayerSpawnPhantomsEvent.class);
 
     private int phantomsToSpawn;
+    private Result result = Result.DEFAULT;
 
     public PlayerSpawnPhantomsEvent(Player player, int phantomsToSpawn) {
         super(player);
@@ -48,6 +50,11 @@ public class PlayerSpawnPhantomsEvent extends PlayerEvent {
         this.phantomsToSpawn = phantomsToSpawn;
     }
 
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
     /**
      * The result of this event controls if phantoms will be spawned.<br>
      * <ul>
@@ -58,6 +65,6 @@ public class PlayerSpawnPhantomsEvent extends PlayerEvent {
      */
     @Override
     public void setResult(@NotNull Result result) {
-        super.setResult(result);
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSpawnPhantomsEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.level.levelgen.PhantomSpawner;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,8 +22,10 @@ import org.jetbrains.annotations.NotNull;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  * @see PlayerSpawnPhantomsEvent#setResult for the effects of each result.
  */
-@Event.HasResult
+@HasResult
 public class PlayerSpawnPhantomsEvent extends PlayerEvent {
+    public static final EventBus<PlayerSpawnPhantomsEvent> BUS = EventBus.create(PlayerSpawnPhantomsEvent.class);
+
     private int phantomsToSpawn;
 
     public PlayerSpawnPhantomsEvent(Player player, int phantomsToSpawn) {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
@@ -6,14 +6,16 @@
 package net.minecraftforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired when the player is waking up.<br/>
  * This is merely for purposes of listening for this to happen.<br/>
  * There is nothing that can be manipulated with this event.
  */
-public class PlayerWakeUpEvent extends PlayerEvent
-{
+public class PlayerWakeUpEvent extends PlayerEvent {
+    public static final EventBus<PlayerWakeUpEvent> BUS = EventBus.create(PlayerWakeUpEvent.class);
+
     private final boolean wakeImmediately;
 
     private final boolean updateLevel;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -50,7 +50,7 @@ public class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     public static class XpChange extends PlayerXpEvent implements Cancellable {
-        private static final CancellableEventBus<XpChange> BUS = CancellableEventBus.create(XpChange.class);
+        public static final CancellableEventBus<XpChange> BUS = CancellableEventBus.create(XpChange.class);
 
         private int amount;
 
@@ -73,7 +73,7 @@ public class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     public static class LevelChange extends PlayerXpEvent implements Cancellable {
-        private static final CancellableEventBus<LevelChange> BUS = CancellableEventBus.create(LevelChange.class);
+        public static final CancellableEventBus<LevelChange> BUS = CancellableEventBus.create(LevelChange.class);
 
         private int levels;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -8,7 +8,9 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * PlayerXpEvent is fired whenever an event involving player experience occurs. <br>
@@ -18,6 +20,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
  */
 public class PlayerXpEvent extends PlayerEvent {
+    public static final EventBus<PlayerXpEvent> BUS = EventBus.create(PlayerXpEvent.class);
+
     public PlayerXpEvent(Player player) {
         super(player);
     }
@@ -26,8 +30,9 @@ public class PlayerXpEvent extends PlayerEvent {
      * This event is fired after the player collides with an experience orb, but before the player has been given the experience.
      * It can be cancelled, and no further processing will be done.
      */
-    @Cancelable
-    public static class PickupXp extends PlayerXpEvent {
+    public static class PickupXp extends PlayerXpEvent implements Cancellable {
+        public static final CancellableEventBus<PickupXp> BUS = CancellableEventBus.create(PickupXp.class);
+
         private final ExperienceOrb orb;
 
         public PickupXp(Player player, ExperienceOrb orb) {
@@ -44,8 +49,9 @@ public class PlayerXpEvent extends PlayerEvent {
      * This event is fired when the player's experience changes through the {@link Player#giveExperiencePoints(int)} method.
      * It can be cancelled, and no further processing will be done.
      */
-    @Cancelable
-    public static class XpChange extends PlayerXpEvent {
+    public static class XpChange extends PlayerXpEvent implements Cancellable {
+        private static final CancellableEventBus<XpChange> BUS = CancellableEventBus.create(XpChange.class);
+
         private int amount;
 
         public XpChange(Player player, int amount) {
@@ -66,8 +72,9 @@ public class PlayerXpEvent extends PlayerEvent {
      * This event is fired when the player's experience level changes through the {@link Player#giveExperienceLevels(int)} method.
      * It can be cancelled, and no further processing will be done.
      */
-    @Cancelable
-    public static class LevelChange extends PlayerXpEvent {
+    public static class LevelChange extends PlayerXpEvent implements Cancellable {
+        private static final CancellableEventBus<LevelChange> BUS = CancellableEventBus.create(LevelChange.class);
+
         private int levels;
 
         public LevelChange(Player player, int levels) {

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -12,7 +12,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.event.entity.living.LivingEvent;
-import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired when game checks, if sleeping player should be still considered "in bed".<br>
@@ -24,8 +24,8 @@ import net.minecraftforge.eventbus.api.Event.HasResult;
  * setResult(DEFAULT) causes game to check {@link Block#isBed(BlockState, BlockGetter, BlockPos, Entity)} instead
  */
 @HasResult
-public class SleepingLocationCheckEvent extends LivingEvent
-{
+public class SleepingLocationCheckEvent extends LivingEvent {
+    public static final EventBus<SleepingLocationCheckEvent> BUS = EventBus.create(SleepingLocationCheckEvent.class);
 
     private final BlockPos sleepingLocation;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -11,6 +11,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
@@ -23,11 +25,11 @@ import net.minecraftforge.eventbus.api.bus.EventBus;
  * setResult(ALLOW) informs game that player is still "in bed"<br>
  * setResult(DEFAULT) causes game to check {@link Block#isBed(BlockState, BlockGetter, BlockPos, Entity)} instead
  */
-@HasResult
-public class SleepingLocationCheckEvent extends LivingEvent {
+public class SleepingLocationCheckEvent extends LivingEvent implements HasResult {
     public static final EventBus<SleepingLocationCheckEvent> BUS = EventBus.create(SleepingLocationCheckEvent.class);
 
     private final BlockPos sleepingLocation;
+    private Result result = Result.DEFAULT;
 
     public SleepingLocationCheckEvent(LivingEntity player, BlockPos sleepingLocation)
     {
@@ -38,5 +40,15 @@ public class SleepingLocationCheckEvent extends LivingEvent {
     public BlockPos getSleepingLocation()
     {
         return sleepingLocation;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 import java.util.Optional;
 
@@ -22,8 +22,9 @@ import java.util.Optional;
  * setResult(DEFAULT) causes game to check !{@link Level#isDay()} instead.
  */
 @HasResult
-public class SleepingTimeCheckEvent extends PlayerEvent
-{
+public class SleepingTimeCheckEvent extends PlayerEvent {
+    public static final EventBus<SleepingTimeCheckEvent> BUS = EventBus.create(SleepingTimeCheckEvent.class);
+
     private final Optional<BlockPos> sleepingLocation;
 
     public SleepingTimeCheckEvent(Player player, Optional<BlockPos> sleepingLocation)

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
 import java.util.Optional;
@@ -21,11 +23,11 @@ import java.util.Optional;
  * setResult(ALLOW) informs game that player can sleep at this time.<br>
  * setResult(DEFAULT) causes game to check !{@link Level#isDay()} instead.
  */
-@HasResult
-public class SleepingTimeCheckEvent extends PlayerEvent {
+public class SleepingTimeCheckEvent extends PlayerEvent implements HasResult {
     public static final EventBus<SleepingTimeCheckEvent> BUS = EventBus.create(SleepingTimeCheckEvent.class);
 
     private final Optional<BlockPos> sleepingLocation;
+    private Result result = Result.DEFAULT;
 
     public SleepingTimeCheckEvent(Player player, Optional<BlockPos> sleepingLocation)
     {
@@ -40,5 +42,15 @@ public class SleepingTimeCheckEvent extends PlayerEvent {
     public Optional<BlockPos> getSleepingLocation()
     {
         return sleepingLocation;
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/TradeWithVillagerEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -20,8 +20,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
-public class TradeWithVillagerEvent extends PlayerEvent
-{
+public class TradeWithVillagerEvent extends PlayerEvent {
+    public static final EventBus<TradeWithVillagerEvent> BUS = EventBus.create(TradeWithVillagerEvent.class);
+
     private final MerchantOffer offer;
     private final AbstractVillager abstractVillager;
 

--- a/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,9 +29,9 @@ import org.jetbrains.annotations.Nullable;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
-@Cancelable
-public class FurnaceFuelBurnTimeEvent extends Event
-{
+public class FurnaceFuelBurnTimeEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<FurnaceFuelBurnTimeEvent> BUS = CancellableEventBus.create(FurnaceFuelBurnTimeEvent.class);
+
     @NotNull
     private final ItemStack itemStack;
     @Nullable
@@ -72,7 +73,8 @@ public class FurnaceFuelBurnTimeEvent extends Event
         if (burnTime >= 0)
         {
             this.burnTime = burnTime;
-            setCanceled(true);
+            // Todo: [Forge][Event] FurnaceFuelBurnTimeEvent calls Event#setCanceled(boolean)
+//            setCanceled(true);
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/AlterGroundEvent.java
@@ -11,8 +11,8 @@ import net.minecraft.world.level.LevelSimulatedReader;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecorator;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.ApiStatus;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
-public class AlterGroundEvent extends Event {
+public class AlterGroundEvent extends MutableEvent {
+    public static final EventBus<AlterGroundEvent> BUS = EventBus.create(AlterGroundEvent.class);
+
     private final LevelSimulatedReader level;
     private final RandomSource random;
     private final BlockPos pos;

--- a/src/main/java/net/minecraftforge/event/level/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/BlockEvent.java
@@ -29,6 +29,7 @@ import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.util.BlockSnapshot;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraftforge.common.util.CancellableAware;
 import net.minecraftforge.common.util.HasResult;
 import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
@@ -69,7 +70,7 @@ public class BlockEvent extends MutableEvent {
      * Event that is fired when an Block is about to be broken by a player
      * Canceling this event will prevent the Block from being broken.
      */
-    public static class BreakEvent extends BlockEvent implements Cancellable {
+    public static class BreakEvent extends BlockEvent implements Cancellable, CancellableAware {
         public static final CancellableEventBus<BreakEvent> BUS = CancellableEventBus.create(BreakEvent.class);
 
         /** Reference to the Player who broke the block. If no player is available, use a EntityFakePlayer */
@@ -374,7 +375,7 @@ public class BlockEvent extends MutableEvent {
      * Fired when when farmland gets trampled
      * This event is {@link Cancelable}
      */
-    public static class FarmlandTrampleEvent extends BlockEvent {
+    public static class FarmlandTrampleEvent extends BlockEvent implements Cancellable {
         public static final CancellableEventBus<FarmlandTrampleEvent> BUS = CancellableEventBus.create(FarmlandTrampleEvent.class);
 
         private final Entity entity;
@@ -401,7 +402,7 @@ public class BlockEvent extends MutableEvent {
      *
      * If cancelled, the portal will not be spawned.
      */
-    public static class PortalSpawnEvent extends BlockEvent {
+    public static class PortalSpawnEvent extends BlockEvent implements Cancellable {
         public static final CancellableEventBus<PortalSpawnEvent> BUS = CancellableEventBus.create(PortalSpawnEvent.class);
 
         private final PortalShape size;
@@ -426,7 +427,7 @@ public class BlockEvent extends MutableEvent {
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
      */
-    public static class BlockToolModificationEvent extends BlockEvent {
+    public static class BlockToolModificationEvent extends BlockEvent implements Cancellable {
         public static final CancellableEventBus<BlockToolModificationEvent> BUS = CancellableEventBus.create(BlockToolModificationEvent.class);
 
         private final UseOnContext context;

--- a/src/main/java/net/minecraftforge/event/level/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/BlockEvent.java
@@ -27,14 +27,18 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class BlockEvent extends Event {
+public class BlockEvent extends MutableEvent {
+    public static final EventBus<BlockEvent> BUS = EventBus.create(BlockEvent.class);
+
     private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("forge.debugBlockEvent", "false"));
 
     private final LevelAccessor level;
@@ -63,8 +67,9 @@ public class BlockEvent extends Event {
      * Event that is fired when an Block is about to be broken by a player
      * Canceling this event will prevent the Block from being broken.
      */
-    @Cancelable
-    public static class BreakEvent extends BlockEvent {
+    public static class BreakEvent extends BlockEvent implements Cancellable {
+        public static final CancellableEventBus<BreakEvent> BUS = CancellableEventBus.create(BreakEvent.class);
+
         /** Reference to the Player who broke the block. If no player is available, use a EntityFakePlayer */
         private final Player player;
         private int exp;
@@ -112,8 +117,9 @@ public class BlockEvent extends Event {
      *
      * If a Block Place event is cancelled, the block will not be placed.
      */
-    @Cancelable
-    public static class EntityPlaceEvent extends BlockEvent {
+    public static class EntityPlaceEvent extends BlockEvent implements Cancellable {
+        public static final CancellableEventBus<EntityPlaceEvent> BUS = CancellableEventBus.create(EntityPlaceEvent.class);
+
         private final Entity entity;
         private final BlockSnapshot blockSnapshot;
         private final BlockState placedBlock;
@@ -145,8 +151,9 @@ public class BlockEvent extends Event {
      * the placed block would exist if the placement only affected a single
      * block.
      */
-    @Cancelable
-    public static class EntityMultiPlaceEvent extends EntityPlaceEvent {
+    public static class EntityMultiPlaceEvent extends EntityPlaceEvent implements Cancellable {
+        public static final CancellableEventBus<EntityMultiPlaceEvent> BUS = CancellableEventBus.create(EntityMultiPlaceEvent.class);
+
         private final List<BlockSnapshot> blockSnapshots;
 
         public EntityMultiPlaceEvent(@NotNull List<BlockSnapshot> blockSnapshots, @NotNull BlockState placedAgainst, @Nullable Entity entity) {
@@ -173,8 +180,9 @@ public class BlockEvent extends Event {
      * a way for mods to detect physics updates, in the same way a BUD switch
      * does. This event is only called on the server.
      */
-    @Cancelable
-    public static class NeighborNotifyEvent extends BlockEvent {
+    public static class NeighborNotifyEvent extends BlockEvent implements Cancellable {
+        public static final CancellableEventBus<NeighborNotifyEvent> BUS = CancellableEventBus.create(NeighborNotifyEvent.class);
+
         private final EnumSet<Direction> notifiedSides;
         private final boolean forceRedstoneUpdate;
 
@@ -209,7 +217,9 @@ public class BlockEvent extends Event {
      * even if the liquid usually does do that (like water).
      */
     @HasResult
-    public static class CreateFluidSourceEvent extends Event {
+    public static class CreateFluidSourceEvent extends MutableEvent {
+        public static final EventBus<CreateFluidSourceEvent> BUS = EventBus.create(CreateFluidSourceEvent.class);
+
         private final Level level;
         private final BlockPos pos;
         private final BlockState state;
@@ -241,8 +251,9 @@ public class BlockEvent extends Event {
      * {@link #getState()} will return the block that was originally going to be placed.
      * {@link #getPos()} will return the position of the block to be changed.
      */
-    @Cancelable
-    public static class FluidPlaceBlockEvent extends BlockEvent {
+    public static class FluidPlaceBlockEvent extends BlockEvent implements Cancellable {
+        public static final CancellableEventBus<FluidPlaceBlockEvent> BUS = CancellableEventBus.create(FluidPlaceBlockEvent.class);
+
         private final BlockPos liquidPos;
         private BlockState newState;
         private BlockState origState;
@@ -285,6 +296,8 @@ public class BlockEvent extends Event {
      *
      */
     public static class CropGrowEvent extends BlockEvent {
+        public static final EventBus<CropGrowEvent> BUS = EventBus.create(CropGrowEvent.class);
+
         public CropGrowEvent(Level level, BlockPos pos, BlockState state) {
             super(level, pos, state);
         }
@@ -302,6 +315,8 @@ public class BlockEvent extends Event {
          */
         @HasResult
         public static class Pre extends CropGrowEvent {
+            public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
             public Pre(Level level, BlockPos pos, BlockState state) {
                 super(level, pos, state);
             }
@@ -317,6 +332,8 @@ public class BlockEvent extends Event {
          * This event does not have a result. {@link HasResult}<br>
          */
         public static class Post extends CropGrowEvent {
+            public static final EventBus<Post> BUS = EventBus.create(Post.class);
+
             private final BlockState originalState;
 
             public Post(Level level, BlockPos pos, BlockState original, BlockState state) {
@@ -334,8 +351,9 @@ public class BlockEvent extends Event {
      * Fired when when farmland gets trampled
      * This event is {@link Cancelable}
      */
-    @Cancelable
     public static class FarmlandTrampleEvent extends BlockEvent {
+        public static final CancellableEventBus<FarmlandTrampleEvent> BUS = CancellableEventBus.create(FarmlandTrampleEvent.class);
+
         private final Entity entity;
         private final float fallDistance;
 
@@ -360,8 +378,9 @@ public class BlockEvent extends Event {
      *
      * If cancelled, the portal will not be spawned.
      */
-    @Cancelable
     public static class PortalSpawnEvent extends BlockEvent {
+        public static final CancellableEventBus<PortalSpawnEvent> BUS = CancellableEventBus.create(PortalSpawnEvent.class);
+
         private final PortalShape size;
 
         public PortalSpawnEvent(LevelAccessor level, BlockPos pos, BlockState state, PortalShape size) {
@@ -384,8 +403,9 @@ public class BlockEvent extends Event {
      * This event is {@link Cancelable}. If canceled, this will prevent the tool
      * from changing the block's state.
      */
-    @Cancelable
     public static class BlockToolModificationEvent extends BlockEvent {
+        public static final CancellableEventBus<BlockToolModificationEvent> BUS = CancellableEventBus.create(BlockToolModificationEvent.class);
+
         private final UseOnContext context;
         private final ToolAction toolAction;
         private final boolean simulate;

--- a/src/main/java/net/minecraftforge/event/level/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/BlockEvent.java
@@ -29,6 +29,8 @@ import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.util.BlockSnapshot;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
@@ -216,13 +218,13 @@ public class BlockEvent extends MutableEvent {
      * usually doesn't do that (like lava), and a result of DENY prevents creation
      * even if the liquid usually does do that (like water).
      */
-    @HasResult
-    public static class CreateFluidSourceEvent extends MutableEvent {
+    public static class CreateFluidSourceEvent extends MutableEvent implements HasResult {
         public static final EventBus<CreateFluidSourceEvent> BUS = EventBus.create(CreateFluidSourceEvent.class);
 
         private final Level level;
         private final BlockPos pos;
         private final BlockState state;
+        private Result result = Result.DEFAULT;
 
         public CreateFluidSourceEvent(Level level, BlockPos pos, BlockState state) {
             this.level = level;
@@ -240,6 +242,16 @@ public class BlockEvent extends MutableEvent {
 
         public BlockState getState() {
             return state;
+        }
+
+        @Override
+        public Result getResult() {
+            return result;
+        }
+
+        @Override
+        public void setResult(Result result) {
+            this.result = result;
         }
     }
 
@@ -313,12 +325,23 @@ public class BlockEvent extends MutableEvent {
          * This event is not {@link Cancelable}.<br>
          * <br>
          */
-        @HasResult
-        public static class Pre extends CropGrowEvent {
+        public static class Pre extends CropGrowEvent implements HasResult {
             public static final EventBus<Pre> BUS = EventBus.create(Pre.class);
+
+            private Result result = Result.DEFAULT;
 
             public Pre(Level level, BlockPos pos, BlockState state) {
                 super(level, pos, state);
+            }
+
+            @Override
+            public Result getResult() {
+                return result;
+            }
+
+            @Override
+            public void setResult(Result result) {
+                this.result = result;
             }
         }
 

--- a/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkDataEvent.java
@@ -13,8 +13,7 @@ import net.minecraft.world.level.chunk.status.ChunkType;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * ChunkDataEvent is fired when an event involving chunk data occurs.<br>
@@ -26,6 +25,8 @@ import net.minecraftforge.eventbus.api.Event;
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
 public class ChunkDataEvent extends ChunkEvent {
+    public static final EventBus<ChunkDataEvent> BUS = EventBus.create(ChunkDataEvent.class);
+
     private final SerializableChunkData data;
 
     public ChunkDataEvent(ChunkAccess chunk, SerializableChunkData data) {
@@ -54,7 +55,9 @@ public class ChunkDataEvent extends ChunkEvent {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
     public static class Load extends ChunkDataEvent {
-        private ChunkType status;
+        public static final EventBus<ChunkDataEvent.Load> BUS = EventBus.create(ChunkDataEvent.Load.class);
+
+        private final ChunkType status;
 
         public Load(ChunkAccess chunk, SerializableChunkData data, ChunkType status) {
             super(chunk, data);
@@ -78,6 +81,8 @@ public class ChunkDataEvent extends ChunkEvent {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
     public static class Save extends ChunkDataEvent {
+        public static final EventBus<ChunkDataEvent.Save> BUS = EventBus.create(ChunkDataEvent.Save.class);
+
         public Save(ChunkAccess chunk, LevelAccessor world, SerializableChunkData data) {
             super(chunk, world, data);
         }

--- a/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkEvent.java
@@ -9,8 +9,7 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -22,8 +21,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class ChunkEvent extends LevelEvent
-{
+public class ChunkEvent extends LevelEvent {
+    public static final EventBus<ChunkEvent> BUS = EventBus.create(ChunkEvent.class);
+
     private final ChunkAccess chunk;
 
     public ChunkEvent(ChunkAccess chunk)
@@ -56,8 +56,9 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Load extends ChunkEvent
-    {
+    public static class Load extends ChunkEvent {
+        public static final EventBus<ChunkEvent.Load> BUS = EventBus.create(ChunkEvent.Load.class);
+
         private final boolean newChunk;
 
         @ApiStatus.Internal
@@ -91,8 +92,9 @@ public class ChunkEvent extends LevelEvent
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class Unload extends ChunkEvent
-    {
+    public static class Unload extends ChunkEvent {
+        public static final EventBus<ChunkEvent.Unload> BUS = EventBus.create(ChunkEvent.Unload.class);
+
         public Unload(ChunkAccess chunk)
         {
             super(chunk);

--- a/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkTicketLevelUpdatedEvent.java
@@ -8,8 +8,8 @@ package net.minecraftforge.event.level;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,8 +29,9 @@ import org.jetbrains.annotations.Nullable;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-public class ChunkTicketLevelUpdatedEvent extends Event
-{
+public class ChunkTicketLevelUpdatedEvent extends MutableEvent {
+    public static final EventBus<ChunkTicketLevelUpdatedEvent> BUS = EventBus.create(ChunkTicketLevelUpdatedEvent.class);
+
     private final ServerLevel level;
     private final long chunkPos;
     private final int oldTicketLevel;

--- a/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ChunkWatchEvent.java
@@ -10,8 +10,8 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -25,7 +25,9 @@ import net.minecraftforge.fml.LogicalSide;
  * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
-public class ChunkWatchEvent extends Event {
+public class ChunkWatchEvent extends MutableEvent {
+    public static final EventBus<ChunkWatchEvent> BUS = EventBus.create(ChunkWatchEvent.class);
+
     private final ServerLevel level;
     private final ServerPlayer player;
     private final ChunkPos pos;
@@ -68,6 +70,8 @@ public class ChunkWatchEvent extends Event {
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     public static class Watch extends ChunkWatchEvent {
+        public static final EventBus<Watch> BUS = EventBus.create(Watch.class);
+
         private final LevelChunk chunk;
 
         public Watch(ServerPlayer player, LevelChunk chunk, ServerLevel level) {
@@ -89,6 +93,8 @@ public class ChunkWatchEvent extends Event {
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     public static class UnWatch extends ChunkWatchEvent {
+        public static final EventBus<UnWatch> BUS = EventBus.create(UnWatch.class);
+
         public UnWatch(ServerPlayer player, ChunkPos pos, ServerLevel level) {
             super(player, pos, level);
         }

--- a/src/main/java/net/minecraftforge/event/level/ExplosionEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/ExplosionEvent.java
@@ -8,12 +8,14 @@ package net.minecraftforge.event.level;
 import java.util.List;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /** ExplosionEvent triggers when an explosion happens in the level.<br>
  * <br>
@@ -25,7 +27,9 @@ import net.minecraft.world.level.Level;
  * Children do not use {@link HasResult}.<br>
  * Children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  */
-public class ExplosionEvent extends Event {
+public class ExplosionEvent extends MutableEvent {
+    public static final EventBus<ExplosionEvent> BUS = EventBus.create(ExplosionEvent.class);
+
     private final Level level;
     private final Explosion explosion;
 
@@ -48,8 +52,9 @@ public class ExplosionEvent extends Event {
      * This event does not use {@link HasResult}.<br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      */
-    @Cancelable
-    public static class Start extends ExplosionEvent {
+    public static class Start extends ExplosionEvent implements Cancellable {
+        public static final CancellableEventBus<Start> BUS = CancellableEventBus.create(Start.class);
+
         public Start(Level level, Explosion explosion) {
             super(level, explosion);
         }
@@ -62,6 +67,8 @@ public class ExplosionEvent extends Event {
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      */
     public static class Detonate extends ExplosionEvent {
+        public static final EventBus<Detonate> BUS = EventBus.create(Detonate.class);
+
         private final List<BlockPos> blocks;
         private final List<Entity> entityList;
 

--- a/src/main/java/net/minecraftforge/event/level/LevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/LevelEvent.java
@@ -23,8 +23,10 @@ import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.storage.ServerLevelData;
 import net.minecraftforge.common.ForgeInternalHandler;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
@@ -32,8 +34,9 @@ import net.minecraftforge.fml.LogicalSide;
  * <p>
  * All children of this event are fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}.
  */
-public class LevelEvent extends Event
-{
+public class LevelEvent extends MutableEvent {
+    public static final EventBus<LevelEvent> BUS = EventBus.create(LevelEvent.class);
+
     private final LevelAccessor level;
 
     public LevelEvent(LevelAccessor level)
@@ -59,8 +62,9 @@ public class LevelEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * on both logical sides.
      **/
-    public static class Load extends LevelEvent
-    {
+    public static class Load extends LevelEvent {
+        public static final EventBus<Load> BUS = EventBus.create(Load.class);
+
         public Load(LevelAccessor level) { super(level); }
     }
 
@@ -77,8 +81,9 @@ public class LevelEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * on both logical sides.
      **/
-    public static class Unload extends LevelEvent
-    {
+    public static class Unload extends LevelEvent {
+        public static final EventBus<Unload> BUS = EventBus.create(Unload.class);
+
         public Unload(LevelAccessor level) { super(level); }
     }
 
@@ -92,8 +97,9 @@ public class LevelEvent extends Event
      * This event is fired on the {@linkplain MinecraftForge#EVENT_BUS main Forge event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
-    public static class Save extends LevelEvent
-    {
+    public static class Save extends LevelEvent {
+        public static final EventBus<Save> BUS = EventBus.create(Save.class);
+
         public Save(LevelAccessor level) { super(level); }
     }
 
@@ -109,9 +115,9 @@ public class LevelEvent extends Event
      *
      * @see ServerLevelData#isInitialized()
      */
-    @Cancelable
-    public static class CreateSpawnPosition extends LevelEvent
-    {
+    public static class CreateSpawnPosition extends LevelEvent implements Cancellable {
+        public static final CancellableEventBus<CreateSpawnPosition> BUS = CancellableEventBus.create(CreateSpawnPosition.class);
+
         private final ServerLevelData settings;
 
         public CreateSpawnPosition(LevelAccessor level, ServerLevelData settings)
@@ -137,9 +143,9 @@ public class LevelEvent extends Event
      * <p>This event is {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
      * Canceling the event will result in an empty list, meaning no entity will be spawned.</p>
      */
-    @Cancelable
-    public static class PotentialSpawns extends LevelEvent
-    {
+    public static class PotentialSpawns extends LevelEvent implements Cancellable {
+        public static final CancellableEventBus<PotentialSpawns> BUS = CancellableEventBus.create(PotentialSpawns.class);
+
         private final MobCategory mobcategory;
         private final BlockPos pos;
         private final List<MobSpawnSettings.SpawnerData> list;

--- a/src/main/java/net/minecraftforge/event/level/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/NoteBlockEvent.java
@@ -9,15 +9,19 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Cancelable;
 
 import com.google.common.base.Preconditions;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * Base class for Noteblock Events
  *
  */
 public class NoteBlockEvent extends BlockEvent {
+    public static final EventBus<NoteBlockEvent> BUS = EventBus.create(NoteBlockEvent.class);
+
     private int noteId;
 
     protected NoteBlockEvent(Level world, BlockPos pos, BlockState state, int note) {
@@ -64,8 +68,9 @@ public class NoteBlockEvent extends BlockEvent {
      * Fired when a Noteblock plays it's note. You can override the note and instrument
      * Canceling this event will stop the note from playing.
      */
-    @Cancelable
-    public static class Play extends NoteBlockEvent {
+    public static class Play extends NoteBlockEvent implements Cancellable {
+        public static final CancellableEventBus<Play> BUS = CancellableEventBus.create(Play.class);
+
         private NoteBlockInstrument instrument;
 
         public Play(Level world, BlockPos pos, BlockState state, int note, NoteBlockInstrument instrument) {
@@ -86,8 +91,9 @@ public class NoteBlockEvent extends BlockEvent {
      * Fired when a Noteblock is changed. You can adjust the note it will change to via {@link #setNote(Note, Octave)}.
      * Canceling this event will not change the note and also stop the Noteblock from playing it's note.
      */
-    @Cancelable
-    public static class Change extends NoteBlockEvent {
+    public static class Change extends NoteBlockEvent implements Cancellable {
+        public static final CancellableEventBus<Change> BUS = CancellableEventBus.create(Change.class);
+
         private final Note oldNote;
         private final Octave oldOctave;
 

--- a/src/main/java/net/minecraftforge/event/level/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/PistonEvent.java
@@ -9,14 +9,16 @@ import net.minecraft.world.level.block.piston.PistonStructureResolver;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Base piston event, use {@link PistonEvent.Post} and {@link PistonEvent.Pre}
  */
-public abstract class PistonEvent extends BlockEvent
-{
+public abstract class PistonEvent extends BlockEvent {
+    public static final EventBus<PistonEvent> BUS = EventBus.create(PistonEvent.class);
 
     private final Direction direction;
     private final PistonMoveType moveType;
@@ -72,8 +74,8 @@ public abstract class PistonEvent extends BlockEvent
     /**
      * Fires after the piston has moved and set surrounding states. This will not fire if {@link PistonEvent.Pre} is cancelled.
      */
-    public static class Post extends PistonEvent
-    {
+    public static class Post extends PistonEvent {
+        public static final EventBus<Post> BUS = EventBus.create(Post.class);
 
         public Post(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)
         {
@@ -85,9 +87,8 @@ public abstract class PistonEvent extends BlockEvent
     /**
      * Fires before the piston has updated block states. Cancellation prevents movement.
      */
-    @Cancelable
-    public static class Pre extends PistonEvent
-    {
+    public static class Pre extends PistonEvent implements Cancellable {
+        public static final CancellableEventBus<Pre> BUS = CancellableEventBus.create(Pre.class);
 
         public Pre(Level world, BlockPos pos, Direction direction, PistonMoveType moveType)
         {

--- a/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
@@ -13,8 +13,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event.HasResult;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -32,6 +31,8 @@ import org.jetbrains.annotations.Nullable;
 @HasResult
 @Deprecated(forRemoval = true, since = "1.21.1") // Dont remove, rename
 public class SaplingGrowTreeEvent extends LevelEvent {
+    public static final EventBus<SaplingGrowTreeEvent> BUS = EventBus.create(SaplingGrowTreeEvent.class);
+
     private final RandomSource randomSource;
     private final BlockPos pos;
     @Nullable

--- a/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SaplingGrowTreeEvent.java
@@ -13,6 +13,8 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.HasResult;
+import net.minecraftforge.common.util.Result;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,15 +30,15 @@ import org.jetbrains.annotations.Nullable;
  * only on the {@linkplain net.minecraftforge.fml.LogicalSide#SERVER logical server}.
  */
 // TODO: Rename to BlockFeatureGrowEvent in 1.20
-@HasResult
 @Deprecated(forRemoval = true, since = "1.21.1") // Dont remove, rename
-public class SaplingGrowTreeEvent extends LevelEvent {
+public class SaplingGrowTreeEvent extends LevelEvent implements HasResult {
     public static final EventBus<SaplingGrowTreeEvent> BUS = EventBus.create(SaplingGrowTreeEvent.class);
 
     private final RandomSource randomSource;
     private final BlockPos pos;
     @Nullable
     private Holder<ConfiguredFeature<?, ?>> feature;
+    private Result result = Result.DEFAULT;
 
     public SaplingGrowTreeEvent(LevelAccessor level, RandomSource randomSource, BlockPos pos, @Nullable Holder<ConfiguredFeature<?, ?>> feature) {
         super(level);
@@ -79,5 +81,15 @@ public class SaplingGrowTreeEvent extends LevelEvent {
      */
     public void setFeature(ResourceKey<ConfiguredFeature<?, ?>> featureKey) {
         this.feature = this.getLevel().registryAccess().lookupOrThrow(Registries.CONFIGURED_FEATURE).get(featureKey).orElse(null);
+    }
+
+    @Override
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Result result) {
+        this.result = result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/level/SleepFinishedTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/level/SleepFinishedTimeEvent.java
@@ -6,14 +6,16 @@
 package net.minecraftforge.event.level;
 
 import net.minecraft.server.level.ServerLevel;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * This event is fired when all players are asleep and the time should be set to day.<br>
  *
  * setWakeUpTime(wakeUpTime) sets a new time that will be added to the dayTime.<br>
  */
-public class SleepFinishedTimeEvent extends LevelEvent
-{
+public class SleepFinishedTimeEvent extends LevelEvent {
+    public static final EventBus<SleepFinishedTimeEvent> BUS = EventBus.create(SleepFinishedTimeEvent.class);
+
     private long newTime;
     private final long minTime;
 

--- a/src/main/java/net/minecraftforge/event/network/ChannelRegistrationChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/ChannelRegistrationChangeEvent.java
@@ -10,7 +10,8 @@ import java.util.Set;
 
 import net.minecraft.network.Connection;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * Fired when the channel registration (see minecraft custom channel documentation) changes.
@@ -18,7 +19,9 @@ import net.minecraftforge.eventbus.api.Event;
  * It seems plausible that this will fire multiple times for the same state, depending on what the server is doing.
  * It just directly dispatches upon receipt.
  */
-public class ChannelRegistrationChangeEvent extends Event {
+public class ChannelRegistrationChangeEvent extends MutableEvent {
+    public static final EventBus<ChannelRegistrationChangeEvent> BUS = EventBus.create(ChannelRegistrationChangeEvent.class);
+
     public enum Type {
         REGISTER, UNREGISTER;
     }

--- a/src/main/java/net/minecraftforge/event/network/ConnectionStartEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/ConnectionStartEvent.java
@@ -5,11 +5,12 @@
 
 package net.minecraftforge.event.network;
 
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.PacketFlow;
-import net.minecraftforge.eventbus.api.Event;
 
 /**
  * Fired when a network connection is started, either on the server when it receives the
@@ -18,7 +19,9 @@ import net.minecraftforge.eventbus.api.Event;
  *
  * As this is a blocking event modders can also do things like load data. Need some example uses.
  */
-public class ConnectionStartEvent extends Event {
+public class ConnectionStartEvent extends MutableEvent {
+    public static final EventBus<ConnectionStartEvent> BUS = EventBus.create(ConnectionStartEvent.class);
+
     private final Connection connection;
 
     @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/event/network/CustomPayloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/CustomPayloadEvent.java
@@ -15,7 +15,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.network.Connection;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.network.ForgePayload;
 import net.minecraftforge.common.util.LogicalSidedProvider;
 import org.jetbrains.annotations.Nullable;
@@ -24,7 +25,9 @@ import java.util.concurrent.CompletableFuture;
 
 // TODO make this not an event, and instead move it to a callback in the Channel itself.
 // But also expose it as a generic listener event for anyone who cares about it but is outside out channel control system.
-public class CustomPayloadEvent extends Event {
+public class CustomPayloadEvent extends MutableEvent {
+    public static final EventBus<CustomPayloadEvent> BUS = EventBus.create(CustomPayloadEvent.class);
+
     private final ResourceLocation channel;
     private final Object payload;
     private final FriendlyByteBuf data;

--- a/src/main/java/net/minecraftforge/event/network/CustomPayloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/CustomPayloadEvent.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 
 // TODO make this not an event, and instead move it to a callback in the Channel itself.
 // But also expose it as a generic listener event for anyone who cares about it but is outside out channel control system.
-public class CustomPayloadEvent extends MutableEvent {
+public final class CustomPayloadEvent extends MutableEvent {
     public static final EventBus<CustomPayloadEvent> BUS = EventBus.create(CustomPayloadEvent.class);
 
     private final ResourceLocation channel;

--- a/src/main/java/net/minecraftforge/event/network/GatherLoginConfigurationTasksEvent.java
+++ b/src/main/java/net/minecraftforge/event/network/GatherLoginConfigurationTasksEvent.java
@@ -9,13 +9,16 @@ import java.util.function.Consumer;
 
 import net.minecraft.network.Connection;
 import net.minecraft.server.network.ConfigurationTask;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * Gathers tasks that need to be run during the initial login configuration.
  * @see net.minecraft.server.network.ServerConfigurationPacketListenerImpl#startConfiguration() startConfiguration
  */
-public class GatherLoginConfigurationTasksEvent extends Event {
+public class GatherLoginConfigurationTasksEvent extends MutableEvent {
+    public static final EventBus<GatherLoginConfigurationTasksEvent> BUS = EventBus.create(GatherLoginConfigurationTasksEvent.class);
+
     private final Connection connection;
     private final Consumer<ConfigurationTask> add;
 

--- a/src/main/java/net/minecraftforge/event/server/ServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerAboutToStartEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 
 /**
@@ -16,6 +17,7 @@ import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
  * @author cpw
  */
 public class ServerAboutToStartEvent extends ServerLifecycleEvent {
+    public static final EventBus<ServerAboutToStartEvent> BUS = EventBus.create(ServerAboutToStartEvent.class);
 
     public ServerAboutToStartEvent(MinecraftServer server)
     {

--- a/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
@@ -6,10 +6,11 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
-public class ServerLifecycleEvent extends Event
-{
+public class ServerLifecycleEvent extends MutableEvent {
+    public static final EventBus<ServerLifecycleEvent> BUS = EventBus.create(ServerLifecycleEvent.class);
 
     protected final MinecraftServer server;
 

--- a/src/main/java/net/minecraftforge/event/server/ServerStartedEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStartedEvent.java
@@ -6,14 +6,15 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called after {@link ServerStartingEvent} when the server is available and ready to play.
  *
  * @author cpw
  */
-public class ServerStartedEvent extends ServerLifecycleEvent
-{
+public class ServerStartedEvent extends ServerLifecycleEvent {
+    public static final EventBus<ServerStartedEvent> BUS = EventBus.create(ServerStartedEvent.class);
 
     public ServerStartedEvent(final MinecraftServer server)
     {

--- a/src/main/java/net/minecraftforge/event/server/ServerStartingEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStartingEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called after {@link ServerAboutToStartEvent} and before {@link ServerStartedEvent}.
@@ -15,8 +16,9 @@ import net.minecraft.server.MinecraftServer;
  *
  * @author cpw
  */
-public class ServerStartingEvent extends ServerLifecycleEvent
-{
+public class ServerStartingEvent extends ServerLifecycleEvent {
+    public static final EventBus<ServerStartingEvent> BUS = EventBus.create(ServerStartingEvent.class);
+
     public ServerStartingEvent(final MinecraftServer server)
     {
         super(server);

--- a/src/main/java/net/minecraftforge/event/server/ServerStoppedEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStoppedEvent.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called after {@link ServerStoppingEvent} when the server has completely shut down.
@@ -15,6 +16,8 @@ import net.minecraft.server.MinecraftServer;
  * @author cpw
  */
 public class ServerStoppedEvent extends ServerLifecycleEvent {
+    public static final EventBus<ServerStoppedEvent> BUS = EventBus.create(ServerStoppedEvent.class);
+
     public ServerStoppedEvent(MinecraftServer server)
     {
         super(server);

--- a/src/main/java/net/minecraftforge/event/server/ServerStoppingEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerStoppingEvent.java
@@ -6,14 +6,16 @@
 package net.minecraftforge.event.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 
 /**
  * Called when the server begins an orderly shutdown, before {@link ServerStoppedEvent}.
  *
  * @author cpw
  */
-public class ServerStoppingEvent extends ServerLifecycleEvent
-{
+public class ServerStoppingEvent extends ServerLifecycleEvent {
+    public static final EventBus<ServerStoppingEvent> BUS = EventBus.create(ServerStoppingEvent.class);
+
     public ServerStoppingEvent(MinecraftServer server)
     {
         super(server);

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -10,8 +10,9 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.ai.village.VillageSiege;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 
 /**
  * VillageSiegeEvent is fired just before a zombie siege finds a successful location in
@@ -23,9 +24,9 @@ import net.minecraftforge.eventbus.api.Event;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  */
-@Cancelable
-public class VillageSiegeEvent extends Event
-{
+public class VillageSiegeEvent extends MutableEvent implements Cancellable {
+    public static final CancellableEventBus<VillageSiegeEvent> BUS = CancellableEventBus.create(VillageSiegeEvent.class);
+
     private final VillageSiege siege;
     private final Level level;
     private final Player player;

--- a/src/main/java/net/minecraftforge/event/village/VillagerTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillagerTradesEvent.java
@@ -12,8 +12,9 @@ import net.minecraft.world.entity.npc.VillagerData;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * VillagerTradesEvent is fired during the {@link ServerAboutToStartEvent}.  It is used to gather the trade lists for each profession.
@@ -25,8 +26,8 @@ import net.minecraftforge.event.server.ServerAboutToStartEvent;
  * Levels outside of this range do nothing, as specified by {@link VillagerData#canLevelUp(int)} which is called before attempting to level up.
  * To add trades to the merchant, simply add new trades to the list. {@link BasicItemListing} provides a default implementation.
  */
-public class VillagerTradesEvent extends Event
-{
+public class VillagerTradesEvent extends MutableEvent {
+    public static final EventBus<VillagerTradesEvent> BUS = EventBus.create(VillagerTradesEvent.class);
 
     protected Int2ObjectMap<List<ItemListing>> trades;
     protected VillagerProfession type;

--- a/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
@@ -9,8 +9,9 @@ import java.util.List;
 
 import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 /**
  * WandererTradesEvent is fired during the {@link ServerAboutToStartEvent}.  It is used to gather the trade lists for the wandering merchant.
@@ -18,8 +19,8 @@ import net.minecraftforge.event.server.ServerAboutToStartEvent;
  * The wandering merchant picks a few trades from {@code generic} and a single trade from {@code rare}.
  * To add trades to the merchant, simply add new trades to the list. {@link BasicItemListing} provides a default implementation.
 */
-public class WandererTradesEvent extends Event
-{
+public class WandererTradesEvent extends MutableEvent {
+    public static final EventBus<WandererTradesEvent> BUS = EventBus.create(WandererTradesEvent.class);
 
     protected List<ItemListing> generic;
     protected List<ItemListing> rare;

--- a/src/main/java/net/minecraftforge/fml/core/ParallelTransition.java
+++ b/src/main/java/net/minecraftforge/fml/core/ParallelTransition.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml.core;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.IModStateTransition;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
@@ -17,10 +16,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 
-record  ParallelTransition(ModLoadingStage stage, BiFunction<ModContainer, ModLoadingStage, ParallelDispatchEvent> event) implements IModStateTransition {
+record ParallelTransition(ModLoadingStage stage, BiFunction<ModContainer, ModLoadingStage, ParallelDispatchEvent> event) implements IModStateTransition {
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends Event & IModBusEvent> EventGenerator<T> eventFunction() {
+    public <T extends IModBusEvent> EventGenerator<T> eventFunction() {
         return EventGenerator.fromFunction(mod -> (T)event.apply(mod, stage));
     }
 

--- a/src/main/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
@@ -5,13 +5,14 @@
 
 package net.minecraftforge.fml.event.config;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.IModBusEvent;
 
 public class ModConfigEvent extends MutableEvent implements IModBusEvent, IConfigEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
     private final ModConfig config;
 
     ModConfigEvent(final ModConfig config) {
@@ -28,6 +29,10 @@ public class ModConfigEvent extends MutableEvent implements IModBusEvent, IConfi
      * Any Config objects associated with this will be valid and can be queried directly.
      */
     public static class Loading extends ModConfigEvent {
+        public static EventBus<Loading> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, Loading.class);
+        }
+
         public Loading(final ModConfig config) {
             super(config);
         }
@@ -40,6 +45,10 @@ public class ModConfigEvent extends MutableEvent implements IModBusEvent, IConfi
      * any resultant changes.
      */
     public static class Reloading extends ModConfigEvent {
+        public static EventBus<Reloading> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, Reloading.class);
+        }
+
         public Reloading(final ModConfig config) {
             super(config);
         }
@@ -52,6 +61,10 @@ public class ModConfigEvent extends MutableEvent implements IModBusEvent, IConfi
      * The config file will be saved after this event has fired.
      */
     public static class Unloading extends ModConfigEvent {
+        public static EventBus<Unloading> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, Unloading.class);
+        }
+
         public Unloading(final ModConfig config) {
             super(config);
         }

--- a/src/main/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/config/ModConfigEvent.java
@@ -5,12 +5,13 @@
 
 package net.minecraftforge.fml.event.config;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.IModBusEvent;
 
-public class ModConfigEvent extends Event implements IModBusEvent, IConfigEvent {
+public class ModConfigEvent extends MutableEvent implements IModBusEvent, IConfigEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
     private final ModConfig config;
 
     ModConfigEvent(final ModConfig config) {

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
@@ -5,8 +5,11 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 
 /**
@@ -24,6 +27,10 @@ import net.minecraftforge.fml.ModLoadingStage;
  * This is a parallel dispatch event.
  */
 public class FMLClientSetupEvent extends ParallelDispatchEvent {
+    public static EventBus<FMLClientSetupEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, FMLClientSetupEvent.class);
+    }
+
     public FMLClientSetupEvent(ModContainer container, ModLoadingStage stage) {
         super(container, stage);
     }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -5,9 +5,12 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 import java.util.function.Consumer;
 
@@ -27,8 +30,11 @@ import java.util.function.Consumer;
  * @see DeferredWorkQueue to enqueue work to run on the main game thread after this event has
  * completed dispatch
  */
-public class FMLCommonSetupEvent extends ParallelDispatchEvent
-{
+public class FMLCommonSetupEvent extends ParallelDispatchEvent {
+    public static EventBus<FMLCommonSetupEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, FMLCommonSetupEvent.class);
+    }
+
     public FMLCommonSetupEvent(final ModContainer container, final ModLoadingStage stage)
     {
         super(container, stage);

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
  * {@link FMLClientSetupEvent} or {@link FMLDedicatedServerSetupEvent} during mod startup.
  *
  * Either register your listener using {@link net.minecraftforge.fml.javafmlmod.AutomaticEventSubscriber} and
- * {@link net.minecraftforge.eventbus.api.SubscribeEvent} or
+ * {@link net.minecraftforge.eventbus.api.listener.SubscribeEvent} or
  * {@link net.minecraftforge.eventbus.api.IEventBus#addListener(Consumer)} in your constructor.
  *
  * Most non-specific mod setup will be performed here. Note that this is a parallel dispatched event - you cannot

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
@@ -5,14 +5,21 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
  * Supplied as a param to your mod's constructor to get access
  * to the mod EventBus and various mod-specific objects.
  */
 public class FMLConstructModEvent extends ParallelDispatchEvent {
+    public static EventBus<FMLConstructModEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, FMLConstructModEvent.class);
+    }
+
     public FMLConstructModEvent(final ModContainer container, final ModLoadingStage stage) {
         super(container, stage);
     }

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
@@ -5,8 +5,11 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
  * This is the second of four commonly called events during mod core startup.
@@ -26,8 +29,11 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class FMLDedicatedServerSetupEvent extends ParallelDispatchEvent
-{
+public class FMLDedicatedServerSetupEvent extends ParallelDispatchEvent {
+    public static EventBus<FMLDedicatedServerSetupEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, FMLDedicatedServerSetupEvent.class);
+    }
+
     public FMLDedicatedServerSetupEvent(ModContainer container, ModLoadingStage stage)
     {
         super(container, stage);

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
@@ -5,8 +5,11 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
  * This is a mostly internal event fired to mod containers that indicates that loading is complete. Mods should not
@@ -14,8 +17,11 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * @author cpw
  */
-public class FMLLoadCompleteEvent extends ParallelDispatchEvent
-{
+public class FMLLoadCompleteEvent extends ParallelDispatchEvent {
+    public static EventBus<FMLLoadCompleteEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, FMLLoadCompleteEvent.class);
+    }
+
     public FMLLoadCompleteEvent(final ModContainer container, final ModLoadingStage stage)
     {
         super(container, stage);

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
@@ -5,8 +5,11 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 /**
  * This is the third of four commonly called events during mod core startup.
@@ -19,8 +22,10 @@ import net.minecraftforge.fml.ModLoadingStage;
  *
  * This is a parallel dispatch event.
  */
-public class InterModEnqueueEvent extends ParallelDispatchEvent
-{
+public class InterModEnqueueEvent extends ParallelDispatchEvent {
+    public static EventBus<InterModEnqueueEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, InterModEnqueueEvent.class);
+    }
 
     public InterModEnqueueEvent(final ModContainer container, final ModLoadingStage stage)
     {

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
@@ -5,8 +5,11 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 import java.util.function.Predicate;
 
@@ -23,8 +26,11 @@ import java.util.function.Predicate;
  * @see #getIMCStream()
  * @see #getIMCStream(Predicate)
  */
-public class InterModProcessEvent extends ParallelDispatchEvent
-{
+public class InterModProcessEvent extends ParallelDispatchEvent {
+    public static EventBus<InterModProcessEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, InterModProcessEvent.class);
+    }
+
     public InterModProcessEvent(final ModContainer container, final ModLoadingStage stage)
     {
         super(container, stage);

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -17,8 +17,8 @@ import java.util.stream.Stream;
  * Parent type to all ModLifecycle events. This is based on Forge EventBus. They fire through the
  * ModContainer's eventbus instance.
  */
-public class ModLifecycleEvent extends Event implements IModBusEvent
-{
+public class ModLifecycleEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
     private final ModContainer container;
 
     public ModLifecycleEvent(ModContainer container)

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
  * ModContainer's eventbus instance.
  */
 public class ModLifecycleEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
     private final ModContainer container;
 
     public ModLifecycleEvent(ModContainer container)

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
@@ -5,9 +5,12 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingStage;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/net/minecraftforge/internal/ForgeBindings.java
+++ b/src/main/java/net/minecraftforge/internal/ForgeBindings.java
@@ -6,8 +6,6 @@
 package net.minecraftforge.internal;
 
 import net.minecraftforge.common.ForgeI18n;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.I18NParser;
 import net.minecraftforge.fml.IBindingsProvider;
 import net.minecraftforge.fml.config.IConfigEvent;
@@ -30,11 +28,6 @@ public final class ForgeBindings implements IBindingsProvider {
         };
 
         private LazyInit() {}
-    }
-
-    @Override
-    public Supplier<IEventBus> getForgeBusSupplier() {
-        return () -> MinecraftForge.EVENT_BUS;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/network/ChannelBuilder.java
+++ b/src/main/java/net/minecraftforge/network/ChannelBuilder.java
@@ -174,7 +174,7 @@ public class ChannelBuilder {
      * @return the {@link NetworkInstance}
      */
     private NetworkInstance createNetworkInstance() {
-        var instance = new NetworkInstance(name, networkProtocolVersion,
+        var instance = NetworkInstance.of(name, networkProtocolVersion,
             getClientAcceptedVersions(), getServerAcceptedVersions(),
             attributes, connectionHandler
         );

--- a/src/main/java/net/minecraftforge/network/EventNetworkChannel.java
+++ b/src/main/java/net/minecraftforge/network/EventNetworkChannel.java
@@ -27,7 +27,7 @@ public class EventNetworkChannel extends Channel<FriendlyByteBuf> {
         super(instance);
     }
 
-    public <T extends CustomPayloadEvent> EventNetworkChannel addListener(Consumer<T> eventListener) {
+    public EventNetworkChannel addListener(Consumer<CustomPayloadEvent> eventListener) {
         instance.addListener(eventListener);
         return this;
     }

--- a/src/main/java/net/minecraftforge/network/NetworkInstance.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInstance.java
@@ -9,6 +9,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.event.network.CustomPayloadEvent;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.network.Channel.VersionTest;
 
 import java.util.HashSet;
@@ -26,37 +27,45 @@ import io.netty.util.AttributeKey;
  * as the internal API and {@link Channel} as the public.
  */
 @ApiStatus.Internal
-public final class NetworkInstance {
+public record NetworkInstance(
+        BusGroup networkEventBusGroup,
+        EventBus<CustomPayloadEvent> eventBus,
+        ResourceLocation channelName,
+        int networkProtocolVersion,
+        VersionTest clientAcceptedVersions,
+        VersionTest serverAcceptedVersions,
+        Map<AttributeKey<?>, Function<Connection, ?>> attributes,
+        Consumer<Connection> channelHandler,
+        ServerStatusPing.ChannelData pingData,
+        Set<ResourceLocation> ids
+) {
     // We use an event bus here so that we don't have to have a handle(event) public function on Channel.
     // Should this be changed so that modders can fire other channel's handlers?
     // Todo: [Forge][Networking] Update the above comment
-    private final BusGroup networkEventBusGroup;
-    private final ResourceLocation channelName;
-    private final int networkProtocolVersion;
-    final VersionTest clientAcceptedVersions;
-    final VersionTest serverAcceptedVersions;
-    final Map<AttributeKey<?>, Function<Connection, ?>> attributes;
-    final Consumer<Connection> channelHandler;
-    final ServerStatusPing.ChannelData pingData;
-    private final Set<ResourceLocation> ids = new HashSet<>();
 
-    NetworkInstance(ResourceLocation channelName, int networkProtocolVersion,
+    static NetworkInstance of(ResourceLocation channelName, int networkProtocolVersion,
         VersionTest clientAcceptedVersions, VersionTest serverAcceptedVersions,
         Map<AttributeKey<?>, Function<Connection, ?>> attributes, Consumer<Connection> channelHandler
     ) {
-        this.channelName = channelName;
-        this.networkProtocolVersion = networkProtocolVersion;
-        this.clientAcceptedVersions = clientAcceptedVersions;
-        this.serverAcceptedVersions = serverAcceptedVersions;
-        this.attributes = attributes;
-        this.channelHandler = channelHandler;
-        this.networkEventBusGroup = BusGroup.create(channelName.toString() + "_networkInstance", CustomPayloadEvent.class);
-        this.pingData = new ServerStatusPing.ChannelData(channelName, networkProtocolVersion, this.clientAcceptedVersions.accepts(VersionTest.Status.MISSING, -1));
+        return new NetworkInstance(
+                channelName, networkProtocolVersion, clientAcceptedVersions, serverAcceptedVersions,
+                BusGroup.create(channelName.toString() + "_networkInstance", CustomPayloadEvent.class),
+                attributes, channelHandler);
     }
 
-    public <T extends CustomPayloadEvent> void addListener(Consumer<T> eventListener) {
+    public NetworkInstance(ResourceLocation channelName, int networkProtocolVersion,
+        VersionTest clientAcceptedVersions, VersionTest serverAcceptedVersions, BusGroup busGroup,
+        Map<AttributeKey<?>, Function<Connection, ?>> attributes, Consumer<Connection> channelHandler
+    ) {
+        this(busGroup, EventBus.create(busGroup, CustomPayloadEvent.class), channelName, networkProtocolVersion,
+                clientAcceptedVersions, serverAcceptedVersions, attributes, channelHandler,
+                new ServerStatusPing.ChannelData(channelName, networkProtocolVersion, clientAcceptedVersions.accepts(VersionTest.Status.MISSING, -1)),
+                new HashSet<>());
+    }
+
+    public void addListener(Consumer<CustomPayloadEvent> eventListener) {
         // TODO: [Forge][Networking] Adjust this to use the new event bus system
-//        this.networkEventBusGroup.addListener(eventListener);
+        eventBus.addListener(eventListener);
     }
 
     public void registerObject(final Object object) {
@@ -70,8 +79,7 @@ public final class NetworkInstance {
     }
 
     public boolean dispatch(CustomPayloadEvent event) {
-        // TODO: [Forge][Networking] Adjust this to use the new event bus system
-//        this.networkEventBusGroup.post(event);
+        this.eventBus.post(event);
         return event.getSource().getPacketHandled();
     }
 

--- a/src/main/java/net/minecraftforge/network/NetworkInstance.java
+++ b/src/main/java/net/minecraftforge/network/NetworkInstance.java
@@ -8,10 +8,7 @@ package net.minecraftforge.network;
 import net.minecraft.network.Connection;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.event.network.CustomPayloadEvent;
-import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.IEventListener;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.network.Channel.VersionTest;
 
 import java.util.HashSet;
@@ -32,7 +29,8 @@ import io.netty.util.AttributeKey;
 public final class NetworkInstance {
     // We use an event bus here so that we don't have to have a handle(event) public function on Channel.
     // Should this be changed so that modders can fire other channel's handlers?
-    private final IEventBus networkEventBus;
+    // Todo: [Forge][Networking] Update the above comment
+    private final BusGroup networkEventBusGroup;
     private final ResourceLocation channelName;
     private final int networkProtocolVersion;
     final VersionTest clientAcceptedVersions;
@@ -52,27 +50,28 @@ public final class NetworkInstance {
         this.serverAcceptedVersions = serverAcceptedVersions;
         this.attributes = attributes;
         this.channelHandler = channelHandler;
-        this.networkEventBus = BusBuilder.builder().setExceptionHandler(this::handleError).useModLauncher().build();
+        this.networkEventBusGroup = BusGroup.create(channelName.toString() + "_networkInstance", CustomPayloadEvent.class);
         this.pingData = new ServerStatusPing.ChannelData(channelName, networkProtocolVersion, this.clientAcceptedVersions.accepts(VersionTest.Status.MISSING, -1));
     }
 
-    private void handleError(IEventBus iEventBus, Event event, IEventListener[] iEventListeners, int i, Throwable throwable) {
-    }
-
     public <T extends CustomPayloadEvent> void addListener(Consumer<T> eventListener) {
-        this.networkEventBus.addListener(eventListener);
+        // TODO: [Forge][Networking] Adjust this to use the new event bus system
+//        this.networkEventBusGroup.addListener(eventListener);
     }
 
     public void registerObject(final Object object) {
-        this.networkEventBus.register(object);
+        // TODO: [Forge][Networking] Adjust this to use the new event bus system
+//        this.networkEventBusGroup.register(object);
     }
 
     public void unregisterObject(final Object object) {
-        this.networkEventBus.unregister(object);
+        // TODO: [Forge][Networking] Adjust this to use the new event bus system
+//        this.networkEventBusGroup.unregister(object);
     }
 
     public boolean dispatch(CustomPayloadEvent event) {
-        this.networkEventBus.post(event);
+        // TODO: [Forge][Networking] Adjust this to use the new event bus system
+//        this.networkEventBusGroup.post(event);
         return event.getSource().getPacketHandled();
     }
 
@@ -101,5 +100,9 @@ public final class NetworkInstance {
     boolean isRemotePresent(Connection con) {
         var channels = NetworkContext.get(con).getRemoteChannels();
         return channels.containsAll(ids);
+    }
+
+    public BusGroup getNetworkEventBusGroup() {
+        return networkEventBusGroup;
     }
 }

--- a/src/main/java/net/minecraftforge/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/network/NetworkRegistry.java
@@ -41,15 +41,15 @@ public class NetworkRegistry {
     static final Logger LOGGER = LogManager.getLogger();
     static final Marker NETREGISTRY = MarkerManager.getMarker("NETREGISTRY");
 
-    private static Map<ResourceLocation, NetworkInstance> instances = Collections.synchronizedMap(new HashMap<>());
-    private static Map<ResourceLocation, NetworkInstance> byName = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<ResourceLocation, NetworkInstance> instances = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<ResourceLocation, NetworkInstance> byName = Collections.synchronizedMap(new HashMap<>());
 
     public static boolean acceptsVanillaClientConnections() {
-        return listRejectedVanillaMods(n -> n.clientAcceptedVersions).isEmpty() && DataPackRegistriesHooks.getSyncedCustomRegistries().isEmpty();
+        return listRejectedVanillaMods(NetworkInstance::clientAcceptedVersions).isEmpty() && DataPackRegistriesHooks.getSyncedCustomRegistries().isEmpty();
     }
 
     public static boolean canConnectToVanillaServer() {
-        return listRejectedVanillaMods(n -> n.serverAcceptedVersions).isEmpty();
+        return listRejectedVanillaMods(NetworkInstance::serverAcceptedVersions).isEmpty();
     }
 
     @Nullable
@@ -60,7 +60,7 @@ public class NetworkRegistry {
     static Map<ResourceLocation, ServerStatusPing.ChannelData> buildChannelVersionsForListPing() {
         var ret = new HashMap<ResourceLocation, ServerStatusPing.ChannelData>();
         for (var channel : instances.values()) {
-            ret.put(channel.getChannelName(), channel.pingData);
+            ret.put(channel.getChannelName(), channel.pingData());
         }
         return ret;
     }
@@ -91,7 +91,7 @@ public class NetworkRegistry {
         Map<ResourceLocation, NetworkMismatchData.Version> results = new HashMap<>();
         for (var net : instances.values()) {
             var name = net.getChannelName();
-            VersionTest test = fromClient ? net.clientAcceptedVersions : net.serverAcceptedVersions;
+            VersionTest test = fromClient ? net.clientAcceptedVersions() : net.serverAcceptedVersions();
 
             var status = VersionTest.Status.MISSING;
             var version = 0;
@@ -133,7 +133,7 @@ public class NetworkRegistry {
                 version = incoming.get(net.getChannelName()).version();
             }
 
-            boolean accepted = net.serverAcceptedVersions.accepts(status, version);
+            boolean accepted = net.serverAcceptedVersions().accepts(status, version);
             LOGGER.debug(NETREGISTRY, "Channel '{}' : Version test of '{} {}' during listping : {}", net.getChannelName(), status, version, accepted ? "ACCEPTED" : "REJECTED");
 
             if (!accepted)
@@ -171,10 +171,10 @@ public class NetworkRegistry {
         ForgeEventFactory.onConnectionStart(connection);
         var channel = connection.channel();
         for (var inst : instances.values()) {
-            if (inst.attributes != null)
-                inst.attributes.forEach((k, v) -> ((Attribute<Object>)channel.attr(k)).compareAndSet(null, (Object)v.apply(connection)));
-            if (inst.channelHandler != null)
-                inst.channelHandler.accept(connection);
+            if (inst.attributes() != null)
+                inst.attributes().forEach((k, v) -> ((Attribute<Object>)channel.attr(k)).compareAndSet(null, (Object)v.apply(connection)));
+            if (inst.channelHandler() != null)
+                inst.channelHandler().accept(connection);
         }
     }
 

--- a/src/main/java/net/minecraftforge/network/tasks/ForgeNetworkConfigurationHandler.java
+++ b/src/main/java/net/minecraftforge/network/tasks/ForgeNetworkConfigurationHandler.java
@@ -8,14 +8,12 @@ package net.minecraftforge.network.tasks;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraftforge.event.network.GatherLoginConfigurationTasksEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.network.ConnectionType;
 import net.minecraftforge.network.NetworkContext;
 
 @ApiStatus.Internal
 public class ForgeNetworkConfigurationHandler {
-    @SubscribeEvent
-    public void gatherInit(GatherLoginConfigurationTasksEvent event) {
+    public static void gatherInit(GatherLoginConfigurationTasksEvent event) {
         var ctx = NetworkContext.get(event.getConnection());
         if (ctx.getType() != ConnectionType.MODDED)
             return;

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
@@ -12,16 +12,16 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.RegistryDataLoader;
 import net.minecraft.resources.ResourceKey;
-import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class DataPackRegistryEvent extends Event implements IModBusEvent
-{
+public class DataPackRegistryEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     @ApiStatus.Internal
     public DataPackRegistryEvent() {}
 
@@ -36,8 +36,9 @@ public class DataPackRegistryEvent extends Event implements IModBusEvent
      * This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
      * on both {@linkplain LogicalSide logical sides}.
      */
-    public static final class NewRegistry extends DataPackRegistryEvent
-    {
+    public static final class NewRegistry extends DataPackRegistryEvent {
+        // Todo: [Forge][Event] BUS from mod BusGroup
+
         private final List<DataPackRegistryData<?>> registryDataList = new ArrayList<>();
 
         @ApiStatus.Internal

--- a/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/DataPackRegistryEvent.java
@@ -12,6 +12,8 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.RegistryDataLoader;
 import net.minecraft.resources.ResourceKey;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -20,8 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 public class DataPackRegistryEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
-
     @ApiStatus.Internal
     public DataPackRegistryEvent() {}
 
@@ -37,7 +37,9 @@ public class DataPackRegistryEvent extends MutableEvent implements IModBusEvent 
      * on both {@linkplain LogicalSide logical sides}.
      */
     public static final class NewRegistry extends DataPackRegistryEvent {
-        // Todo: [Forge][Event] BUS from mod BusGroup
+        public static EventBus<NewRegistry> getBus(BusGroup modEventBusGroup) {
+            return IModBusEvent.getBus(modEventBusGroup, NewRegistry.class);
+        }
 
         private final List<DataPackRegistryData<?>> registryDataList = new ArrayList<>();
 

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -12,13 +12,14 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.registries.tags.ITagManager;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -318,8 +319,8 @@ public class DeferredRegister<T> {
      *
      * @param bus The Mod Specific event bus.
      */
-    public void register(IEventBus bus) {
-        bus.register(new EventDispatcher());
+    public void register(BusGroup busGroup) {
+        new EventDispatcher().register(busGroup);
     }
 
     /**
@@ -372,7 +373,13 @@ public class DeferredRegister<T> {
         return value;
     }
 
-    private class EventDispatcher {
+    private final class EventDispatcher {
+        private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+        public void register(BusGroup busGroup) {
+            busGroup.register(LOOKUP, this);
+        }
+
         @SubscribeEvent
         public void handleEvent(RegisterEvent event) {
             if (event.getRegistryKey().equals(registryKey)) {

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -13,7 +13,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.registries.tags.ITagManager;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/net/minecraftforge/registries/ForgeDeferredRegistriesSetup.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeDeferredRegistriesSetup.java
@@ -5,9 +5,8 @@
 
 package net.minecraftforge.registries;
 
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import org.jetbrains.annotations.ApiStatus;
-
-import net.minecraftforge.eventbus.api.IEventBus;
 
 @ApiStatus.Internal
 public class ForgeDeferredRegistriesSetup {
@@ -16,7 +15,7 @@ public class ForgeDeferredRegistriesSetup {
     /**
      * Internal forge method. Modders do not call.
      */
-    public static void setup(IEventBus modEventBus) {
+    public static void setup(BusGroup modEventBusGroup) {
         synchronized (ForgeDeferredRegistriesSetup.class) {
             if (setup)
                 throw new IllegalStateException("Setup has already been called!");
@@ -25,6 +24,6 @@ public class ForgeDeferredRegistriesSetup {
         }
 
         for (var reg : ForgeRegistries.registries)
-            reg.register(modEventBus);
+            reg.register(modEventBusGroup);
     }
 }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -619,7 +619,7 @@ public class GameData {
                 ForgeRegistry<?> reg = STAGING.getRegistry(name);
                 Object2IntMap<ResourceLocation> missingIds = m.getValue();
                 MissingMappingsEvent event = reg.getMissingEvent(name, missingIds);
-                MinecraftForge.EVENT_BUS.post(event);
+                MissingMappingsEvent.BUS.post(event);
 
                 List<MissingMappingsEvent.Mapping<?>> lst = event.getAllMappings(reg.getRegistryKey()).stream()
                         .filter(e -> e.action == MissingMappingsEvent.Action.DEFAULT)
@@ -699,7 +699,7 @@ public class GameData {
     }
 
     private static void fireRemapEvent(final Map<ResourceLocation, Map<ResourceLocation, IdMappingEvent.IdRemapping>> remaps, final boolean isFreezing) {
-        MinecraftForge.EVENT_BUS.post(new IdMappingEvent(remaps, isFreezing));
+        IdMappingEvent.BUS.post(new IdMappingEvent(remaps, isFreezing));
     }
 
     //Has to be split because of generics, Yay!

--- a/src/main/java/net/minecraftforge/registries/IdMappingEvent.java
+++ b/src/main/java/net/minecraftforge/registries/IdMappingEvent.java
@@ -10,7 +10,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 
 import java.util.Comparator;
 import java.util.List;
@@ -28,8 +29,9 @@ import java.util.Map;
  * <p>
  * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS forge bus}.
  */
-public class IdMappingEvent extends Event
-{
+public class IdMappingEvent extends MutableEvent {
+    public static final EventBus<IdMappingEvent> BUS = EventBus.create(IdMappingEvent.class);
+
     public static class ModRemapping
     {
         public final ResourceLocation registry;

--- a/src/main/java/net/minecraftforge/registries/MissingMappingsEvent.java
+++ b/src/main/java/net/minecraftforge/registries/MissingMappingsEvent.java
@@ -8,7 +8,8 @@ package net.minecraftforge.registries;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import org.apache.commons.lang3.Validate;
 
 import java.util.Collection;
@@ -18,8 +19,9 @@ import java.util.Locale;
 /**
  * Fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS forge bus}.
  */
-public class MissingMappingsEvent extends Event
-{
+public class MissingMappingsEvent extends MutableEvent {
+    public static final EventBus<MissingMappingsEvent> BUS = EventBus.create(MissingMappingsEvent.class);
+
     private final ResourceKey<? extends Registry<?>> key;
     private final IForgeRegistry<?> registry;
     private final List<Mapping<?>> mappings;

--- a/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
@@ -14,6 +14,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.Nullable;
@@ -23,7 +25,9 @@ import org.slf4j.Logger;
  * Register new registries when you receive this event through {@link RegistryBuilder} and {@link #create(RegistryBuilder)}.
  */
 public class NewRegistryEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<NewRegistryEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, NewRegistryEvent.class);
+    }
 
     private static final Logger LOGGER = LogUtils.getLogger();
     private final List<RegistryData<?>> registries = new ArrayList<>();

--- a/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
@@ -14,7 +14,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -22,7 +22,9 @@ import org.slf4j.Logger;
 /**
  * Register new registries when you receive this event through {@link RegistryBuilder} and {@link #create(RegistryBuilder)}.
  */
-public class NewRegistryEvent extends Event implements IModBusEvent {
+public class NewRegistryEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     private static final Logger LOGGER = LogUtils.getLogger();
     private final List<RegistryData<?>> registries = new ArrayList<>();
 

--- a/src/main/java/net/minecraftforge/registries/RegisterEvent.java
+++ b/src/main/java/net/minecraftforge/registries/RegisterEvent.java
@@ -8,6 +8,8 @@ package net.minecraftforge.registries;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
+import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -26,7 +28,9 @@ import java.util.function.Supplier;
  * @see #register(ResourceKey, Consumer)
  */
 public class RegisterEvent extends MutableEvent implements IModBusEvent {
-    // Todo: [Forge][Event] BUS from mod BusGroup
+    public static EventBus<RegisterEvent> getBus(BusGroup modEventBusGroup) {
+        return IModBusEvent.getBus(modEventBusGroup, RegisterEvent.class);
+    }
 
     @NotNull
     private final ResourceKey<? extends Registry<?>> registryKey;

--- a/src/main/java/net/minecraftforge/registries/RegisterEvent.java
+++ b/src/main/java/net/minecraftforge/registries/RegisterEvent.java
@@ -8,7 +8,7 @@ package net.minecraftforge.registries;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +25,9 @@ import java.util.function.Supplier;
  * @see #register(ResourceKey, ResourceLocation, Supplier)
  * @see #register(ResourceKey, Consumer)
  */
-public class RegisterEvent extends Event implements IModBusEvent {
+public class RegisterEvent extends MutableEvent implements IModBusEvent {
+    // Todo: [Forge][Event] BUS from mod BusGroup
+
     @NotNull
     private final ResourceKey<? extends Registry<?>> registryKey;
     @Nullable

--- a/src/main/java/net/minecraftforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/minecraftforge/server/ServerLifecycleHooks.java
@@ -77,7 +77,7 @@ public class ServerLifecycleHooks {
         LogicalSidedProvider.setServer(()->server);
         ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SERVER, getServerConfigPath(server));
         runModifiers(server);
-        return !MinecraftForge.EVENT_BUS.post(new ServerAboutToStartEvent(server));
+        return !ServerAboutToStartEvent.BUS.post(new ServerAboutToStartEvent(server));
     }
 
     public static boolean handleServerStarting(final MinecraftServer server) {
@@ -88,7 +88,7 @@ public class ServerLifecycleHooks {
                 net.minecraftforge.gametest.ForgeGameTestHooks.registerGametests();
         });
         PermissionAPI.initializePermissionAPI();
-        return !MinecraftForge.EVENT_BUS.post(new ServerStartingEvent(server));
+        return !ServerStartingEvent.BUS.post(new ServerStartingEvent(server));
     }
 
 
@@ -98,7 +98,7 @@ public class ServerLifecycleHooks {
 
     public static void handleServerStopped(final MinecraftServer server) {
         if (!server.isDedicatedServer()) GameData.revertToFrozen();
-        MinecraftForge.EVENT_BUS.post(new ServerStoppedEvent(server));
+        ServerStoppedEvent.BUS.post(new ServerStoppedEvent(server));
         currentServer = null;
         LogicalSidedProvider.setServer(null);
         CountDownLatch latch = exitLatch;
@@ -149,13 +149,13 @@ public class ServerLifecycleHooks {
     //==================================================================================================================================================================================
 
     public static void handleServerStarted(final MinecraftServer server) {
-        MinecraftForge.EVENT_BUS.post(new ServerStartedEvent(server));
+        ServerStartedEvent.BUS.post(new ServerStartedEvent(server));
         allowLogins.set(true);
     }
 
     public static void handleServerStopping(final MinecraftServer server) {
         allowLogins.set(false);
-        MinecraftForge.EVENT_BUS.post(new ServerStoppingEvent(server));
+        ServerStoppingEvent.BUS.post(new ServerStoppingEvent(server));
     }
 
     public static boolean handleServerLogin(final ClientIntentionPacket packet, final Connection connection) {

--- a/src/main/java/net/minecraftforge/server/loading/ServerModLoader.java
+++ b/src/main/java/net/minecraftforge/server/loading/ServerModLoader.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.server.loading;
 
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.fml.*;
 import net.minecraftforge.logging.CrashReportExtender;
 import net.minecraftforge.common.util.LogicalSidedProvider;
@@ -42,7 +43,7 @@ public class ServerModLoader
             LOGGER.warn(Logging.LOADING, "Mods loaded with {} warnings", warnings.size());
             warnings.forEach(warning -> LOGGER.warn(Logging.LOADING, warning.formatToString()));
         }
-        MinecraftForge.EVENT_BUS.start();
+        BusGroup.DEFAULT.startup();
     }
 
     public static boolean hasErrors() {

--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -105,7 +105,7 @@ public final class PermissionAPI
         PermissionAPI.activeHandler = null;
 
         PermissionGatherEvent.Handler handlerEvent = new PermissionGatherEvent.Handler();
-        MinecraftForge.EVENT_BUS.post(handlerEvent);
+        PermissionGatherEvent.Handler.BUS.post(handlerEvent);
         Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = handlerEvent.getAvailablePermissionHandlerFactories();
 
         try
@@ -120,7 +120,7 @@ public final class PermissionAPI
             IPermissionHandlerFactory factory = availableHandlers.get(selectedPermissionHandler);
 
             PermissionGatherEvent.Nodes nodesEvent = new PermissionGatherEvent.Nodes();
-            MinecraftForge.EVENT_BUS.post(nodesEvent);
+            PermissionGatherEvent.Nodes.BUS.post(nodesEvent);
 
             PermissionAPI.activeHandler = factory.create(nodesEvent.getNodes());
 

--- a/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
+++ b/src/main/java/net/minecraftforge/server/permission/events/PermissionGatherEvent.java
@@ -7,7 +7,8 @@ package net.minecraftforge.server.permission.events;
 
 import com.google.common.base.Preconditions;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.server.permission.handler.DefaultPermissionHandler;
 import net.minecraftforge.server.permission.handler.IPermissionHandler;
 import net.minecraftforge.server.permission.handler.IPermissionHandlerFactory;
@@ -25,17 +26,18 @@ import java.util.function.Function;
  *
  * <p><strong>Note:</strong> All PermissionNodes that you want to use, <strong>must</strong> be registered!</p>
  */
-public class PermissionGatherEvent extends Event
-{
+public class PermissionGatherEvent extends MutableEvent {
+    public static final EventBus<PermissionGatherEvent> BUS = EventBus.create(PermissionGatherEvent.class);
 
     /**
      * Used to register a new PermissionHandler, a server config value exists to choose which one to use.
      * <p>Note: Create a new instance when registering a PermissionHandler.
      * If you cache it, make sure that your PermissionHandler is actually used after this event.</p>
      */
-    public static class Handler extends PermissionGatherEvent
-    {
-        private Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
+    public static class Handler extends PermissionGatherEvent {
+        public static final EventBus<Handler> BUS = EventBus.create(Handler.class);
+
+        private final Map<ResourceLocation, IPermissionHandlerFactory> availableHandlers = new HashMap<>();
 
         public Handler()
         {
@@ -61,8 +63,9 @@ public class PermissionGatherEvent extends Event
     /**
      * Used to register your PermissionNodes, <strong>every node that you want to use, must be registered!</strong>
      */
-    public static class Nodes extends PermissionGatherEvent
-    {
+    public static class Nodes extends PermissionGatherEvent {
+        public static final EventBus<Nodes> BUS = EventBus.create(Nodes.class);
+
         private final Set<PermissionNode<?>> nodes = new HashSet<>();
 
         public Nodes()

--- a/src/test/java/com/example/examplemod/Config.java
+++ b/src/test/java/com/example/examplemod/Config.java
@@ -3,7 +3,7 @@ package com.example.examplemod;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
 import net.minecraftforge.registries.ForgeRegistries;

--- a/src/test/java/com/example/examplemod/ExampleMod.java
+++ b/src/test/java/com/example/examplemod/ExampleMod.java
@@ -13,10 +13,9 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
-import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -27,6 +26,8 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.slf4j.Logger;
+
+import java.lang.invoke.MethodHandles;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(ExampleMod.MODID)
@@ -76,23 +77,23 @@ public class ExampleMod {
             }).build());
 
     public ExampleMod(FMLJavaModLoadingContext context) {
-        IEventBus modEventBus = context.getModEventBus();
+        BusGroup modBusGroup = context.getModEventBus();
 
         // Register the commonSetup method for modloading
-        modEventBus.addListener(this::commonSetup);
+        FMLCommonSetupEvent.getBus(modBusGroup).addListener(this::commonSetup);
 
         // Register the Deferred Register to the mod event bus so blocks get registered
-        BLOCKS.register(modEventBus);
+        BLOCKS.register(modBusGroup);
         // Register the Deferred Register to the mod event bus so items get registered
-        ITEMS.register(modEventBus);
+        ITEMS.register(modBusGroup);
         // Register the Deferred Register to the mod event bus so tabs get registered
-        CREATIVE_MODE_TABS.register(modEventBus);
+        CREATIVE_MODE_TABS.register(modBusGroup);
 
         // Register ourselves for server and other game events we are interested in
-        MinecraftForge.EVENT_BUS.register(this);
+        BusGroup.DEFAULT.register(MethodHandles.lookup(), this);
 
         // Register the item to a creative tab
-        modEventBus.addListener(this::addCreative);
+        BuildCreativeModeTabContentsEvent.getBus(modBusGroup).addListener(this::addCreative);
 
         // Register our mod's ForgeConfigSpec so that Forge can create and load the config file for us
         context.registerConfig(ModConfig.Type.COMMON, Config.SPEC);

--- a/src/test/java/com/example/examplemod/ExampleMod.java
+++ b/src/test/java/com/example/examplemod/ExampleMod.java
@@ -17,7 +17,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;

--- a/src/test/java/net/minecraftforge/debug/client/AdditionalModelTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/AdditionalModelTest.java
@@ -44,7 +44,7 @@ import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLLoader;

--- a/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/GuiLayeringTest.java
@@ -16,7 +16,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.client.gui.widget.ExtendedButton;
 import net.minecraftforge.client.gui.widget.ForgeSlider;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import java.util.Random;
@@ -27,6 +27,8 @@ public class GuiLayeringTest {
 
     private static final Random RANDOM = new Random();
     public static final String MODID = "gui_layer_test";
+
+
 
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
     public static class ClientEvents {

--- a/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRenderLayerTest.java
@@ -40,7 +40,7 @@ import net.minecraft.world.level.material.PushReaction;
 import net.minecraftforge.client.ChunkRenderTypeSet;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/gameplay/block/ChorusBlockPlacementTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/block/ChorusBlockPlacementTest.java
@@ -16,7 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.BlockTagsProvider;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/ConditionalRecipeTest.java
@@ -38,7 +38,7 @@ import net.minecraftforge.common.crafting.conditions.IConditionBuilder;
 import net.minecraftforge.common.data.BlockTagsProvider;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/gameplay/crafting/CustomIngredientsTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/crafting/CustomIngredientsTest.java
@@ -44,7 +44,7 @@ import net.minecraftforge.common.data.BlockTagsProvider;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.util.INBTBuilder;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.test.BaseTestMod;

--- a/src/test/java/net/minecraftforge/debug/gameplay/criterion/CriterionTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/criterion/CriterionTest.java
@@ -35,7 +35,7 @@ import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ForgeAdvancementProvider;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.level.BlockEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/gameplay/data/DatapackBuiltinEntriesProviderTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/data/DatapackBuiltinEntriesProviderTest.java
@@ -25,7 +25,7 @@ import net.minecraftforge.common.data.DatapackBuiltinEntriesProvider;
 import net.minecraftforge.common.world.BiomeModifier;
 import net.minecraftforge.common.world.ForgeBiomeModifiers;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.ForgeRegistries;

--- a/src/test/java/net/minecraftforge/debug/gameplay/item/ItemCapabilityTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/item/ItemCapabilityTest.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.EnergyStorage;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/ConditionalLootPools.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/ConditionalLootPools.java
@@ -21,7 +21,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.test.BaseTestMod;
 import net.minecraftforge.fml.common.Mod;

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
@@ -61,7 +61,7 @@ import net.minecraftforge.common.data.GlobalLootModifierProvider;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.loot.LootModifier;
 import net.minecraftforge.common.loot.LootTableIdCondition;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraftforge.test.BaseTestMod;

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/LootEventsTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/LootEventsTest.java
@@ -32,7 +32,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.conditions.IConditionBuilder;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.LootTableLoadEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/modules/closed/ClosedMod.java
+++ b/src/test/java/net/minecraftforge/debug/modules/closed/ClosedMod.java
@@ -11,7 +11,7 @@ import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.debug.modules.closed.api.PublicUtils;
 import net.minecraftforge.debug.modules.closed.internala.InternalA;
 import net.minecraftforge.debug.modules.closed.internalb.InternalB;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.test.BaseTestMod;

--- a/src/test/java/net/minecraftforge/debug/modules/closedtest/ClosedTestsMod.java
+++ b/src/test/java/net/minecraftforge/debug/modules/closedtest/ClosedTestsMod.java
@@ -10,7 +10,7 @@ import java.util.jar.Manifest;
 
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.debug.modules.closed.api.PublicUtils;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/debug/network/PacketTest.java
+++ b/src/test/java/net/minecraftforge/debug/network/PacketTest.java
@@ -20,7 +20,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.network.CustomPayloadEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;

--- a/src/test/java/net/minecraftforge/debug/registries/NetworkDatapackRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/registries/NetworkDatapackRegistryTest.java
@@ -23,7 +23,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.data.DatapackBuiltinEntriesProvider;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.gametest.GameTestHolder;

--- a/src/test/java/net/minecraftforge/test/BaseTestMod.java
+++ b/src/test/java/net/minecraftforge/test/BaseTestMod.java
@@ -21,7 +21,7 @@ import net.minecraft.world.item.CreativeModeTab.TabVisibility;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 

--- a/src/test/java/net/minecraftforge/test/TestHelperMod.java
+++ b/src/test/java/net/minecraftforge/test/TestHelperMod.java
@@ -19,7 +19,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.data.event.GatherDataEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.RegisterEvent;


### PR DESCRIPTION
Supersedes https://github.com/MinecraftForge/MinecraftForge/pull/10495.

Unlike the PoC PR, this tries to get it compiling and booting, without taking full advantage of the new features.

My observations from this experiment:
- FML is really, really horrible in regards to getting this working. So many gross hacks and workarounds involved...
    - Classloader shenanigans where you sometimes have the event instance but can't call `getClass()` on it
    - ~~Thread-safety issues, sometimes requires multiple attempts to successfully boot~~
- The separation of cancellation state from the event object itself is problematic for patches and various events
    -  A lot of events do a `fire()`, check `isCanceled()` and may read other parts of the event object even when cancelled. The separation of cancellation state means that you need to hold the object, post(), then conditionally return null for some events, and longer patches for other events
    - Some events even call `setCanceled()` inside certain unrelated methods or set a custom cancellation state before the event is posted
    - I gave up after awhile and put a dummy interface in place to move onto other areas
- Forge's networking assumes the old architecture. Can get it working with more effort, but not a find and replace level of change and may need some internal redesign
- `RenderHighlightEvent.Entity` seems to have an oversight where it's not intentionally cancellable but inherits cancellable from the superclass
- `RenderLivingEvent` involves instance generics that aren't accessible from a static final context. Not sure how to solve this

This compiles and boots, but fails to load into a world due to the networking internals not being fully ported over yet.

<img width="429" alt="image" src="https://github.com/user-attachments/assets/1083bf40-1ebb-4e96-9961-d322a9248ba5" />